### PR TITLE
Allow resolver errors

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -27,6 +27,7 @@ $RefParser.dereference("my-schema.yaml", {
       withCredentials: true,        // Include auth credentials when resolving HTTP references
     }
   },
+  failFast: true,                   // Abort upon first exception
   dereference: {
     circular: false                 // Don't allow circular $refs
   }

--- a/docs/ref-parser.md
+++ b/docs/ref-parser.md
@@ -6,6 +6,7 @@ This is the default export of JSON Schema $Ref Parser.  You can creates instance
 ##### Properties
 - [`schema`](#schema)
 - [`$refs`](#refs)
+- [`errors`](#errors)
 
 ##### Methods
 - [`dereference()`](#dereferenceschema-options-callback)
@@ -40,6 +41,14 @@ parser.$refs.paths();           // => [] empty array
 
 await parser.dereference("my-schema.json");
 parser.$refs.paths();       // => ["my-schema.json"]
+```
+
+### `errors`
+The `errors` property contains all list of errors that occurred during the bundling/resolving/dereferencing process.
+All errors share error properties:
+- path - json path to the document property. Empty in case of resolving or certain parsing errors.
+- message
+- source - the uri of document that caused the error 
 ```
 
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -96,7 +96,11 @@ function crawl (parent, key, path, pathFromRoot, indirections, inventory, $refs,
 function inventory$Ref ($refParent, $refKey, path, pathFromRoot, indirections, inventory, $refs, options) {
   let $ref = $refKey === null ? $refParent : $refParent[$refKey];
   let $refPath = url.resolve(path, $ref.$ref);
-  let pointer = $refs._resolve($refPath, options);
+  let pointer = $refs._resolve($refPath, pathFromRoot, options);
+  if (pointer === null) {
+    return;
+  }
+
   let depth = Pointer.parse(pathFromRoot).length;
   let file = url.stripHash(pointer.path);
   let hash = url.getHash(pointer.path);

--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -96,7 +96,14 @@ function dereference$Ref ($ref, path, pathFromRoot, parents, $refs, options) {
   // console.log('Dereferencing $ref pointer "%s" at %s', $ref.$ref, path);
 
   let $refPath = url.resolve(path, $ref.$ref);
-  let pointer = $refs._resolve($refPath, options);
+  let pointer = $refs._resolve($refPath, pathFromRoot, options);
+
+  if (pointer === null) {
+    return {
+      circular: false,
+      value: null,
+    };
+  }
 
   // Check for circular references
   let directCircular = pointer.circular;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -26,6 +26,13 @@ declare class $RefParser {
   $refs: $RefParser.$Refs
 
   /**
+   * List of all errors
+   *
+   * See https://github.com/APIDevTools/json-schema-ref-parser/blob/master/docs/ref-parser.md#errors
+   */
+  errors: Array<$RefParser.GenericError | $RefParser.ResolverError | $RefParser.ParserError | $RefParser.MissingPointerError>;
+
+  /**
    * Dereferences all `$ref` pointers in the JSON Schema, replacing each reference with its resolved value. This results in a schema object that does not contain any `$ref` pointers. Instead, it's a normal JavaScript object tree that can easily be crawled and used just like any other JavaScript object. This is great for programmatic usage, especially when using tools that don't understand JSON references.
    *
    * The dereference method maintains object reference equality, meaning that all `$ref` pointers that point to the same object will be replaced with references to the same object. Again, this is great for programmatic usage, but it does introduce the risk of circular references, so be careful if you intend to serialize the schema using `JSON.stringify()`. Consider using the bundle method instead, which does not create circular references.
@@ -209,6 +216,12 @@ declare namespace $RefParser {
     } & {
       [key: string]: Partial<ResolverOptions>
     }
+
+    /**
+     * Determines how lenient the processing should be.
+     * If this option is enable, the processing will be performed in a bail mode - will abort upon the first exception.
+     */
+    failFast?: boolean;
 
     /**
      * The `dereference` options control how JSON Schema `$Ref` Parser will dereference `$ref` pointers within the JSON schema.
@@ -398,4 +411,15 @@ declare namespace $RefParser {
     set($ref: string, value: JSONSchema4Type | JSONSchema6Type): void
   }
 
+  export class GenericError extends Error {
+    readonly message: string;
+    readonly path: Array<string | number>;
+    readonly source: string;
+  }
+
+  export class ParserError extends GenericError {}
+  export class ResolverError extends GenericError {
+    readonly code?: string;
+  }
+  export class MissingPointerError extends GenericError {}
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,11 +8,16 @@ const resolveExternal = require("./resolve-external");
 const bundle = require("./bundle");
 const dereference = require("./dereference");
 const url = require("./util/url");
+const { GenericError, MissingPointerError, ResolverError, ParserError, isHandledError } = require("./util/errors");
 const maybe = require("call-me-maybe");
 const { ono } = require("ono");
 
 module.exports = $RefParser;
 module.exports.YAML = require("./util/yaml");
+module.exports.GenericError = GenericError;
+module.exports.MissingPointerError = MissingPointerError;
+module.exports.ResolverError = ResolverError;
+module.exports.ParserError = ParserError;
 
 /**
  * This class parses a JSON schema, builds a map of its JSON references and their resolved values,
@@ -37,6 +42,25 @@ function $RefParser () {
    */
   this.$refs = new $Refs();
 }
+
+/**
+ * List of all errors
+ * @type {Array<GenericError | ResolverError | ParserError | MissingPointerError>}
+ */
+Object.defineProperty($RefParser.prototype, "errors", {
+  get () {
+    const errors = [];
+
+    for (const $ref of Object.values(this.$refs._$refs)) {
+      if ($ref.errors) {
+        errors.push(...$ref.errors);
+      }
+    }
+
+    return errors;
+  },
+  enumerable: true,
+});
 
 /**
  * Parses the given JSON schema.
@@ -119,8 +143,16 @@ $RefParser.prototype.parse = async function (path, schema, options, callback) {
       return maybe(args.callback, Promise.resolve(me.schema));
     }
   }
-  catch (e) {
-    return maybe(args.callback, Promise.reject(e));
+  catch (err) {
+    if (args.options.failFast || !isHandledError(err)) {
+      return maybe(args.callback, Promise.reject(err));
+    }
+
+    if (this.$refs._$refs[url.stripHash(args.path)]) {
+      this.$refs._$refs[url.stripHash(args.path)].addError(err);
+    }
+
+    return maybe(args.callback, Promise.resolve(null));
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,12 +135,16 @@ $RefParser.prototype.parse = async function (path, schema, options, callback) {
   try {
     let result = await promise;
 
-    if (!result || typeof result !== "object" || Buffer.isBuffer(result)) {
-      throw ono.syntax(`"${me.$refs._root$Ref.path || result}" is not a valid JSON Schema`);
-    }
-    else {
+    if (result !== null && typeof result === "object" && !Buffer.isBuffer(result)) {
       me.schema = result;
       return maybe(args.callback, Promise.resolve(me.schema));
+    }
+    else if (!args.options.failFast) {
+      me.schema = null; // it's already set to null at line 79, but let's set it again for the sake of readability
+      return maybe(args.callback, Promise.resolve(me.schema));
+    }
+    else {
+      throw ono.syntax(`"${me.$refs._root$Ref.path || result}" is not a valid JSON Schema`);
     }
   }
   catch (err) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -26,7 +26,7 @@ $RefParserOptions.defaults = {
    * Determines how different types of files will be parsed.
    *
    * You can add additional parsers of your own, replace an existing one with
-   * your own implemenation, or disable any parser by setting it to false.
+   * your own implementation, or disable any parser by setting it to false.
    */
   parse: {
     json: jsonParser,
@@ -39,7 +39,7 @@ $RefParserOptions.defaults = {
    * Determines how JSON References will be resolved.
    *
    * You can add additional resolvers of your own, replace an existing one with
-   * your own implemenation, or disable any resolver by setting it to false.
+   * your own implementation, or disable any resolver by setting it to false.
    */
   resolve: {
     file: fileResolver,
@@ -54,6 +54,12 @@ $RefParserOptions.defaults = {
      */
     external: true,
   },
+
+  /**
+   * Determines how lenient the processing should be.
+   * If this option is enable, the processing will be performed in a bail mode - will abort upon the first exception.
+  */
+  failFast: true,
 
   /**
    * Determines the types of JSON references that are allowed.

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -3,6 +3,7 @@
 const { ono } = require("ono");
 const url = require("./util/url");
 const plugins = require("./util/plugins");
+const { StoplightParserError, ResolverError, ParserError } = require("./util/errors");
 
 module.exports = parse;
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,6 @@
 "use strict";
 
+
 const { ono } = require("ono");
 const url = require("./util/url");
 const plugins = require("./util/plugins");

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -18,21 +18,21 @@ module.exports = parse;
  * The promise resolves with the parsed file contents, NOT the raw (Buffer) contents.
  */
 async function parse (path, $refs, options) {
+  // Remove the URL fragment, if any
+  path = url.stripHash(path);
+
+  // Add a new $Ref for this file, even though we don't have the value yet.
+  // This ensures that we don't simultaneously read & parse the same file multiple times
+  let $ref = $refs._add(path);
+
+  // This "file object" will be passed to all resolvers and parsers.
+  let file = {
+    url: path,
+    extension: url.getExtension(path),
+  };
+
+  // Read the file and then parse the data
   try {
-    // Remove the URL fragment, if any
-    path = url.stripHash(path);
-
-    // Add a new $Ref for this file, even though we don't have the value yet.
-    // This ensures that we don't simultaneously read & parse the same file multiple times
-    let $ref = $refs._add(path);
-
-    // This "file object" will be passed to all resolvers and parsers.
-    let file = {
-      url: path,
-      extension: url.getExtension(path),
-    };
-
-    // Read the file and then parse the data
     const resolver = await readFile(file, options, $refs);
     $ref.pathType = resolver.plugin.name;
     file.data = resolver.result;
@@ -42,8 +42,14 @@ async function parse (path, $refs, options) {
 
     return parser.result;
   }
-  catch (e) {
-    return Promise.reject(e);
+  catch (ex) {
+    if (!("error" in ex)) {
+      throw ex;
+    }
+    else {
+      $ref.value = ex.error;
+      throw ex.error;
+    }
   }
 }
 
@@ -74,11 +80,15 @@ function readFile (file, options, $refs) {
     function onError (err) {
       // Throw the original error, if it's one of our own (user-friendly) errors.
       // Otherwise, throw a generic, friendly error.
-      if (err && !(err instanceof SyntaxError)) {
+      if (!err || !("error" in err)) {
+        reject(ono.syntax(`Unable to resolve $ref pointer "${file.url}"`));
+      }
+      else if (err.error instanceof ResolverError) {
         reject(err);
       }
       else {
-        reject(ono.syntax(`Unable to resolve $ref pointer "${file.url}"`));
+        err.error = new ResolverError(err, file.url);
+        reject(err);
       }
     }
   }));
@@ -113,7 +123,7 @@ function parseFile (file, options, $refs) {
       .then(onParsed, onError);
 
     function onParsed (parser) {
-      if (!parser.plugin.allowEmpty && isEmpty(parser.result)) {
+      if ((!options.failFast || !parser.plugin.allowEmpty) && isEmpty(parser.result)) {
         reject(ono.syntax(`Error parsing "${file.url}" as ${parser.plugin.name}. \nParsed value is empty`));
       }
       else {
@@ -122,12 +132,19 @@ function parseFile (file, options, $refs) {
     }
 
     function onError (err) {
-      if (err) {
+      if (!err) {
+        reject(ono.syntax(`Unable to parse ${file.url}`));
+      }
+      else if (!("error" in err)) {
         err = err instanceof Error ? err : new Error(err);
         reject(ono.syntax(err, `Error parsing ${file.url}`));
       }
+      else if (err.error instanceof ParserError || err.error instanceof StoplightParserError) {
+        reject(err);
+      }
       else {
-        reject(ono.syntax(`Unable to parse ${file.url}`));
+        err.error = new ParserError(err.error.message, file.url);
+        reject(err);
       }
     }
   }));

--- a/lib/parsers/binary.js
+++ b/lib/parsers/binary.js
@@ -41,7 +41,7 @@ module.exports = {
    * @param {string} file.url       - The full URL of the referenced file
    * @param {string} file.extension - The lowercased file extension (e.g. ".txt", ".html", etc.)
    * @param {*}      file.data      - The file contents. This will be whatever data type was returned by the resolver
-   * @returns {Promise<Buffer>}
+   * @returns {Buffer}
    */
   parse (file) {
     if (Buffer.isBuffer(file.data)) {

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -1,5 +1,9 @@
 "use strict";
 
+const { parseWithPointers } = require("@stoplight/json");
+const { StoplightParserError } = require("../util/errors");
+
+
 module.exports = {
   /**
    * The order that this parser will run, in relation to other parsers.
@@ -21,7 +25,7 @@ module.exports = {
    * Parsers that don't match will be skipped, UNLESS none of the parsers match, in which case
    * every parser will be tried.
    *
-   * @type {RegExp|string[]|function}
+   * @type {RegExp|string|string[]|function}
    */
   canParse: ".json",
 
@@ -34,25 +38,31 @@ module.exports = {
    * @param {*}      file.data      - The file contents. This will be whatever data type was returned by the resolver
    * @returns {Promise}
    */
-  parse (file) {
-    return new Promise(((resolve, reject) => {
-      let data = file.data;
-      if (Buffer.isBuffer(data)) {
-        data = data.toString();
-      }
+  async parse (file) {
+    let data = file.data;
+    if (Buffer.isBuffer(data)) {
+      data = data.toString();
+    }
 
-      if (typeof data === "string") {
-        if (data.trim().length === 0) {
-          resolve(undefined);  // This mirrors the YAML behavior
-        }
-        else {
-          resolve(JSON.parse(data));
-        }
+    if (typeof data === "string") {
+      if (data.trim().length === 0) {
+        return;
       }
       else {
-        // data is already a JavaScript value (object, array, number, null, NaN, etc.)
-        resolve(data);
+        let result = parseWithPointers(data, {
+          ignoreDuplicateKeys: false,
+        });
+
+        if (StoplightParserError.hasErrors(result.diagnostics)) {
+          throw new StoplightParserError(result.diagnostics, file.url);
+        }
+
+        return result.data;
       }
-    }));
+    }
+    else {
+      // data is already a JavaScript value (object, array, number, null, NaN, etc.)
+      return data;
+    }
   }
 };

--- a/lib/parsers/text.js
+++ b/lib/parsers/text.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { ParserError } = require("../util/errors");
+
 let TEXT_REGEXP = /\.(txt|htm|html|md|xml|js|min|map|css|scss|less|svg)$/i;
 
 module.exports = {
@@ -48,7 +50,7 @@ module.exports = {
    * @param {string} file.url       - The full URL of the referenced file
    * @param {string} file.extension - The lowercased file extension (e.g. ".txt", ".html", etc.)
    * @param {*}      file.data      - The file contents. This will be whatever data type was returned by the resolver
-   * @returns {Promise<string>}
+   * @returns {string}
    */
   parse (file) {
     if (typeof file.data === "string") {
@@ -58,7 +60,7 @@ module.exports = {
       return file.data.toString(this.encoding);
     }
     else {
-      throw new Error("data is not text");
+      throw new ParserError("data is not text", file.url);
     }
   }
 };

--- a/lib/parsers/yaml.js
+++ b/lib/parsers/yaml.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const YAML = require("../util/yaml");
+const { StoplightParserError } = require("../util/errors");
 
 module.exports = {
   /**
@@ -36,20 +37,23 @@ module.exports = {
    * @param {*}      file.data      - The file contents. This will be whatever data type was returned by the resolver
    * @returns {Promise}
    */
-  parse (file) {
-    return new Promise(((resolve, reject) => {
-      let data = file.data;
-      if (Buffer.isBuffer(data)) {
-        data = data.toString();
+  async parse (file) {
+    let data = file.data;
+    if (Buffer.isBuffer(data)) {
+      data = data.toString();
+    }
+
+    if (typeof data === "string") {
+      let result = YAML.parse(data);
+      if (StoplightParserError.hasErrors(result.diagnostics)) {
+        throw new StoplightParserError(result.diagnostics, file.url);
       }
 
-      if (typeof data === "string") {
-        resolve(YAML.parse(data));
-      }
-      else {
-        // data is already a JavaScript value (object, array, number, null, NaN, etc.)
-        resolve(data);
-      }
-    }));
+      return result.data;
+    }
+    else {
+      // data is already a JavaScript value (object, array, number, null, NaN, etc.)
+      return data;
+    }
   }
 };

--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -4,7 +4,7 @@ module.exports = Pointer;
 
 const $Ref = require("./ref");
 const url = require("./util/url");
-const { ono } = require("ono");
+const { GenericError, MissingPointerError, isHandledError } = require("./util/errors");
 const slashes = /\//g;
 const tildes = /~/g;
 const escapedSlash = /~1/g;
@@ -75,7 +75,8 @@ Pointer.prototype.resolve = function (obj, options) {
   let tokens = Pointer.parse(this.path);
 
   // Crawl the object, one token at a time
-  this.value = obj;
+  this.value = unwrapOrThrow(obj);
+
   for (let i = 0; i < tokens.length; i++) {
     if (resolveIf$Ref(this, options)) {
       // The $ref path has changed, so append the remaining tokens to the path
@@ -83,8 +84,9 @@ Pointer.prototype.resolve = function (obj, options) {
     }
 
     let token = tokens[i];
-    if (this.value[token] === undefined) {
-      throw ono.syntax(`Error resolving $ref pointer "${this.originalPath}". \nToken "${token}" does not exist.`);
+    if (this.value[token] === undefined || this.value[token] === null) {
+      this.value = null;
+      throw new MissingPointerError(token, this.originalPath);
     }
     else {
       this.value = this.value[token];
@@ -117,7 +119,8 @@ Pointer.prototype.set = function (obj, value, options) {
   }
 
   // Crawl the object, one token at a time
-  this.value = obj;
+  this.value = unwrapOrThrow(obj);
+
   for (let i = 0; i < tokens.length - 1; i++) {
     resolveIf$Ref(this, options);
 
@@ -171,7 +174,7 @@ Pointer.parse = function (path) {
   }
 
   if (pointer[0] !== "") {
-    throw ono.syntax(`Invalid $ref pointer "${pointer}". Pointers must begin with "#/"`);
+    throw new GenericError(`Invalid $ref pointer "${pointer}". Pointers must begin with "#/"`);
   }
 
   return pointer.slice(1);
@@ -222,7 +225,7 @@ function resolveIf$Ref (pointer, options) {
       pointer.circular = true;
     }
     else {
-      let resolved = pointer.$ref.$refs._resolve($refPath, options);
+      let resolved = pointer.$ref.$refs._resolve($refPath, url.getHash(pointer.path), options);
       pointer.indirections += resolved.indirections + 1;
 
       if ($Ref.isExtended$Ref(pointer.value)) {
@@ -264,7 +267,16 @@ function setValue (pointer, token, value) {
     }
   }
   else {
-    throw ono.syntax(`Error assigning $ref pointer "${pointer.path}". \nCannot set "${token}" of a non-object.`);
+    throw new GenericError(`Error assigning $ref pointer "${pointer.path}". \nCannot set "${token}" of a non-object.`);
   }
+  return value;
+}
+
+
+function unwrapOrThrow (value) {
+  if (isHandledError(value)) {
+    throw value;
+  }
+
   return value;
 }

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -3,6 +3,7 @@
 module.exports = $Ref;
 
 const Pointer = require("./pointer");
+const { GenericError, GenericErrorGroup, ParserError, MissingPointerError, ResolverError } = require("./util/errors");
 
 /**
  * This class represents a single JSON reference and its resolved value.
@@ -40,7 +41,33 @@ function $Ref () {
    * @type {?string}
    */
   this.pathType = undefined;
+
+  /**
+   * List of all errors. Undefined if no errors.
+   * @type {Array<GenericError | ResolverError | ParserError | MissingPointerError>}
+   */
+  this.errors = undefined;
 }
+
+/**
+ * Pushes an error to errors array.
+ *
+ * @param {Array<GenericError | GenericErrorGroup>} error - The error to be pushed
+ * @returns {void}
+ */
+$Ref.prototype.addError = function (err) {
+  if (this.errors === undefined) {
+    this.errors = [];
+  }
+
+  if (Array.isArray(err.errors)) {
+    this.errors.push(...err.errors);
+  }
+  else {
+    this.errors.push(err);
+  }
+};
+
 
 /**
  * Determines whether the given JSON reference exists within this {@link $Ref#value}.

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -3,7 +3,8 @@
 module.exports = $Ref;
 
 const Pointer = require("./pointer");
-const { GenericError, GenericErrorGroup, ParserError, MissingPointerError, ResolverError } = require("./util/errors");
+const { GenericError, GenericErrorGroup, ParserError, MissingPointerError, ResolverError, isHandledError } = require("./util/errors");
+const { safePointerToPath } = require("./util/url");
 
 /**
  * This class represents a single JSON reference and its resolved value.
@@ -78,6 +79,7 @@ $Ref.prototype.addError = function (err) {
  */
 $Ref.prototype.exists = function (path, options) {
   try {
+    // todo: should we return false here for option.failFast=false?
     this.resolve(path, options);
     return true;
   }
@@ -102,12 +104,24 @@ $Ref.prototype.get = function (path, options) {
  *
  * @param {string} path - The full path being resolved, optionally with a JSON pointer in the hash
  * @param {$RefParserOptions} options
- * @param {string} [friendlyPath] - The original user-specified path (used for error messages)
+ * @param {string} friendlyPath - The original user-specified path (used for error messages)
+*  @param {string} pathFromRoot - The path of `obj` from the schema root
  * @returns {Pointer}
  */
-$Ref.prototype.resolve = function (path, options, friendlyPath) {
+$Ref.prototype.resolve = function (path, options, friendlyPath, pathFromRoot) {
   let pointer = new Pointer(this, path, friendlyPath);
-  return pointer.resolve(this.value, options);
+  try {
+    return pointer.resolve(this.value, options);
+  }
+  catch (err) {
+    if (!options || options.failFast || !isHandledError(err)) {
+      throw err;
+    }
+
+    err.path = safePointerToPath(pathFromRoot);
+    this.addError(err);
+    return null;
+  }
 };
 
 /**

--- a/lib/refs.js
+++ b/lib/refs.js
@@ -79,7 +79,7 @@ $Refs.prototype.toJSON = $Refs.prototype.values;
  */
 $Refs.prototype.exists = function (path, options) {
   try {
-    this._resolve(path, options);
+    this._resolve(path, "", options);
     return true;
   }
   catch (e) {
@@ -95,7 +95,7 @@ $Refs.prototype.exists = function (path, options) {
  * @returns {*} - Returns the resolved value
  */
 $Refs.prototype.get = function (path, options) {
-  return this._resolve(path, options).value;
+  return this._resolve(path, "", options).value;
 };
 
 /**
@@ -139,11 +139,12 @@ $Refs.prototype._add = function (path) {
  * Resolves the given JSON reference.
  *
  * @param {string} path - The path being resolved, optionally with a JSON pointer in the hash
+ * @param {string} pathFromRoot - The path of `obj` from the schema root
  * @param {$RefParserOptions} [options]
  * @returns {Pointer}
  * @protected
  */
-$Refs.prototype._resolve = function (path, options) {
+$Refs.prototype._resolve = function (path, pathFromRoot, options) {
   let absPath = url.resolve(this._root$Ref.path, path);
   let withoutHash = url.stripHash(absPath);
   let $ref = this._$refs[withoutHash];
@@ -152,7 +153,7 @@ $Refs.prototype._resolve = function (path, options) {
     throw ono(`Error resolving $ref pointer "${path}". \n"${withoutHash}" not found.`);
   }
 
-  return $ref.resolve(absPath, options, path);
+  return $ref.resolve(absPath, options, path, pathFromRoot);
 };
 
 /**

--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -4,6 +4,7 @@ const $Ref = require("./ref");
 const Pointer = require("./pointer");
 const parse = require("./parse");
 const url = require("./util/url");
+const { isHandledError } = require("./util/errors");
 
 module.exports = resolveExternal;
 
@@ -101,11 +102,25 @@ async function resolve$Ref ($ref, path, $refs, options) {
   }
 
   // Parse the $referenced file/url
-  const result = await parse(resolvedPath, $refs, options);
+  try {
+    const result = await parse(resolvedPath, $refs, options);
 
-  // Crawl the parsed value
-  // console.log('Resolving $ref pointers in %s', withoutHash);
-  let promises = crawl(result, withoutHash + "#", $refs, options);
+    // Crawl the parsed value
+    // console.log('Resolving $ref pointers in %s', withoutHash);
+    let promises = crawl(result, withoutHash + "#", $refs, options);
 
-  return Promise.all(promises);
+    return Promise.all(promises);
+  }
+  catch (err) {
+    if (options.failFast || !isHandledError(err)) {
+      throw err;
+    }
+
+    if ($refs._$refs[withoutHash]) {
+      err.source = url.stripHash(path);
+      $refs._$refs[withoutHash].addError(err);
+    }
+
+    return [];
+  }
 }

--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -118,6 +118,7 @@ async function resolve$Ref ($ref, path, $refs, options) {
 
     if ($refs._$refs[withoutHash]) {
       err.source = url.stripHash(path);
+      err.path = url.safePointerToPath(url.getHash(path));
       $refs._$refs[withoutHash].addError(err);
     }
 

--- a/lib/resolvers/file.js
+++ b/lib/resolvers/file.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const { ono } = require("ono");
 const url = require("../util/url");
+const { ResolverError } = require("../util/errors");
 
 module.exports = {
   /**
@@ -40,7 +41,7 @@ module.exports = {
         path = url.toFileSystemPath(file.url);
       }
       catch (err) {
-        reject(ono.uri(err, `Malformed URI: ${file.url}`));
+        reject(new ResolverError(ono.uri(err, `Malformed URI: ${file.url}`), file.url));
       }
 
       // console.log('Opening file: %s', path);
@@ -48,7 +49,7 @@ module.exports = {
       try {
         fs.readFile(path, (err, data) => {
           if (err) {
-            reject(ono(err, `Error opening file "${path}"`));
+            reject(new ResolverError(ono(err, `Error opening file "${path}"`), path));
           }
           else {
             resolve(data);
@@ -56,7 +57,7 @@ module.exports = {
         });
       }
       catch (err) {
-        reject(ono(err, `Error opening file "${path}"`));
+        reject(new ResolverError(ono(err, `Error opening file "${path}"`), path));
       }
     }));
   }

--- a/lib/resolvers/http.js
+++ b/lib/resolvers/http.js
@@ -4,6 +4,7 @@ const http = require("http");
 const https = require("https");
 const { ono } = require("ono");
 const url = require("../util/url");
+const { ResolverError } = require("../util/errors");
 
 module.exports = {
   /**
@@ -123,7 +124,7 @@ function download (u, httpOptions, redirects) {
         }
       })
       .catch((err) => {
-        reject(ono(err, `Error downloading ${u.href}`));
+        reject(new ResolverError(ono(err, `Error downloading ${u.href}`), u.href));
       });
   }));
 }
@@ -160,7 +161,9 @@ function get (u, httpOptions) {
       req.abort();
     });
 
-    req.on("error", reject);
+    req.on("error", ex => {
+      reject(new ResolverError(ex.message, u.href));
+    });
 
     req.once("response", (res) => {
       res.body = Buffer.alloc(0);
@@ -169,7 +172,9 @@ function get (u, httpOptions) {
         res.body = Buffer.concat([res.body, Buffer.from(data)]);
       });
 
-      res.on("error", reject);
+      res.on("error", ex => {
+        reject(new ResolverError(ex.message, u.href));
+      });
 
       res.on("end", () => {
         resolve(res);

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const { stripHash } = require("./url");
+
+const GenericError = exports.GenericError = class GenericError extends Error {
+  constructor (message, source) {
+    super();
+
+    this.message = message;
+    this.source = source;
+    this.path = [];
+  }
+};
+
+setErrorName(GenericError);
+
+const GenericErrorGroup = exports.GenericErrorGroup = class GenericErrorGroup extends Error {
+  constructor (errors, source) {
+    super();
+
+    this.source = source;
+    this.errors = errors;
+  }
+};
+
+exports.StoplightParserError = class StoplightParserError extends GenericErrorGroup {
+  constructor (errors, source) {
+    super(errors.filter(error => error.severity === 0).map(error => {
+      const parsingError = new ParserError(error.message, source);
+      parsingError.message = error.message;
+      if (error.path) {
+        parsingError.path = error.path;
+      }
+
+      return parsingError;
+    }));
+
+    this.message = `Error parsing ${source}`;
+  }
+};
+
+const ParserError = exports.ParserError = class ParserError extends GenericError {
+  constructor (message, source) {
+    super(`Error parsing ${source}: ${message}`, source);
+  }
+};
+
+setErrorName(ParserError);
+
+const ResolverError = exports.ResolverError = class ResolverError extends GenericError {
+  constructor (ex, source) {
+    super(ex.message || `Error reading file ${source}`, source);
+    if ("code" in ex) {
+      this.code = String(ex.code);
+    }
+  }
+};
+
+setErrorName(ResolverError);
+
+const MissingPointerError = exports.MissingPointerError = class MissingPointerError extends GenericError {
+  constructor (token, path) {
+    super(`Token "${token}" does not exist.`, stripHash(path));
+  }
+};
+
+setErrorName(MissingPointerError);
+
+function setErrorName (err) {
+  Object.defineProperty(err.prototype, "name", {
+    value: err.name,
+    enumerable: true,
+  });
+}
+
+exports.isHandledError = function (err) {
+  return err instanceof GenericError || err instanceof GenericErrorGroup;
+};

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -24,8 +24,8 @@ const GenericErrorGroup = exports.GenericErrorGroup = class GenericErrorGroup ex
 };
 
 exports.StoplightParserError = class StoplightParserError extends GenericErrorGroup {
-  constructor (errors, source) {
-    super(errors.filter(error => error.severity === 0).map(error => {
+  constructor (diagnostics, source) {
+    super(diagnostics.filter(StoplightParserError.pickError).map(error => {
       const parsingError = new ParserError(error.message, source);
       parsingError.message = error.message;
       if (error.path) {
@@ -36,6 +36,14 @@ exports.StoplightParserError = class StoplightParserError extends GenericErrorGr
     }));
 
     this.message = `Error parsing ${source}`;
+  }
+
+  static pickError (diagnostic) {
+    return diagnostic.severity === 0;
+  }
+
+  static hasErrors (diagnostics) {
+    return diagnostics.some(StoplightParserError.pickError);
   }
 };
 

--- a/lib/util/plugins.js
+++ b/lib/util/plugins.js
@@ -108,9 +108,12 @@ exports.run = function (plugins, method, file, $refs) {
       });
     }
 
-    function onError (err) {
+    function onError (error) {
       // console.log('    %s', err.message || err);
-      lastError = err;
+      lastError = {
+        plugin,
+        error,
+      };
       runNextPlugin();
     }
   }));

--- a/lib/util/url.js
+++ b/lib/util/url.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { pointerToPath } = require("@stoplight/json");
+
 let isWindows = /^win/.test(process.platform),
     forwardSlashPattern = /\//g,
     protocolPattern = /^(\w{2,}):\/\//i,
@@ -219,4 +221,20 @@ exports.toFileSystemPath = function toFileSystemPath (path, keepFileProtocol) {
   }
 
   return path;
+};
+
+/**
+ * Converts a $ref pointer to a valid JSON Path.
+ * It _does not_ throw.
+ *
+ * @param {string}  pointer
+ * @returns {Array<number | string>}
+ */
+exports.safePointerToPath = function safePointerToPath (pointer) {
+  try {
+    return pointerToPath(pointer);
+  }
+  catch (ex) {
+    return [];
+  }
 };

--- a/lib/util/yaml.js
+++ b/lib/util/yaml.js
@@ -1,8 +1,7 @@
 /* eslint lines-around-comment: [2, {beforeBlockComment: false}] */
 "use strict";
 
-const yaml = require("js-yaml");
-const { ono } = require("ono");
+const { parseWithPointers, safeStringify } = require("@stoplight/yaml");
 
 /**
  * Simple YAML parsing functions, similar to {@link JSON.parse} and {@link JSON.stringify}
@@ -16,18 +15,11 @@ module.exports = {
    * @returns {*}
    */
   parse (text, reviver) {
-    try {
-      return yaml.safeLoad(text);
-    }
-    catch (e) {
-      if (e instanceof Error) {
-        throw e;
-      }
-      else {
-        // https://github.com/nodeca/js-yaml/issues/153
-        throw ono(e, e.message);
-      }
-    }
+    return parseWithPointers(text, {
+      json: true,
+      mergeKeys: true,
+      ignoreDuplicateKeys: false,
+    });
   },
 
   /**
@@ -39,18 +31,7 @@ module.exports = {
    * @returns {string}
    */
   stringify (value, replacer, space) {
-    try {
-      let indent = (typeof space === "string" ? space.length : space) || 2;
-      return yaml.safeDump(value, { indent });
-    }
-    catch (e) {
-      if (e instanceof Error) {
-        throw e;
-      }
-      else {
-        // https://github.com/nodeca/js-yaml/issues/153
-        throw ono(e, e.message);
-      }
-    }
+    let indent = (typeof space === "string" ? space.length : space) || 2;
+    return safeStringify(value, { indent });
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -932,6 +932,40 @@
         "fastq": "^1.6.0"
       }
     },
+    "@stoplight/json": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.5.1.tgz",
+      "integrity": "sha512-O5WUW2yfAvtrqeq60YrbxpTvk87Ti2IeJ5oVa2XNJ2s+IIxx0CM+j316QoOjSGs+twrRpwb3jT9CFPrq7Ghkzg==",
+      "requires": {
+        "@stoplight/types": "^11.4.0",
+        "jsonc-parser": "~2.2.0",
+        "lodash": "^4.17.15",
+        "safe-stable-stringify": "^1.1"
+      }
+    },
+    "@stoplight/types": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.4.0.tgz",
+      "integrity": "sha512-kMh1Sv7bA8BdbUaRXsRyi2K8Y5PzPOUWNSjB4qKOi0P6+dLczjlKggEIw9Xzuu1tCgBFdEvNwjnYDey0iqgeZQ==",
+      "requires": {
+        "@types/json-schema": "^7.0.3"
+      }
+    },
+    "@stoplight/yaml": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-3.5.1.tgz",
+      "integrity": "sha512-pMhLVgHy/jYpKg6NKHEfWHB/k2sbmXpcRCtekvae8L98KcG8C3hEr2O+Hlft/5FE/PqIpb92lYh4/ypk0gN6Gg==",
+      "requires": {
+        "@stoplight/types": "^11.1.1",
+        "@stoplight/yaml-ast-parser": "0.0.44",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@stoplight/yaml-ast-parser": {
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.44.tgz",
+      "integrity": "sha512-PdY8p2Ufgtorf4d2DbKMfknILMa8KwuyyMMR/2lgK1mLaU8F5PKWYc+h9hIzC+ar0bh7m9h2rINo32m7ADfVyA=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -958,8 +992,7 @@
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
-      "dev": true
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -2293,6 +2326,12 @@
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
       }
+    },
+    "chai-subset": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.6.0.tgz",
+      "integrity": "sha1-pdDKFOMpp5WW7XAFi2ZGvWmIz+k=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -5661,6 +5700,11 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonc-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+      "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -6015,8 +6059,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -8499,6 +8542,11 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.0.tgz",
+      "integrity": "sha512-8h+96qSufNQrydRPzbHms38VftQQSRGbqUkaIMWUBWN4/N8sLNALIALa8KmFcQ8P/a9uzMkA+KY04Rj5WQiXPA=="
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/json-schema": "^7.0.4",
     "@types/node": "^13.1.2",
     "chai": "^4.2.0",
+    "chai-subset": "^1.6.0",
     "coveralls": "^3.0.9",
     "eslint": "^6.8.0",
     "eslint-config-modular": "^7.0.1",
@@ -68,6 +69,8 @@
     "version-bump-prompt": "^5.0.7"
   },
   "dependencies": {
+    "@stoplight/json": "^3.5.1",
+    "@stoplight/yaml": "^3.5.1",
     "call-me-maybe": "^1.0.1",
     "js-yaml": "^3.13.1",
     "ono": "^6.0.0"

--- a/test/specs/callbacks.spec.js
+++ b/test/specs/callbacks.spec.js
@@ -4,6 +4,7 @@ const { expect } = require("chai");
 const $RefParser = require("../../lib");
 const helper = require("../utils/helper");
 const path = require("../utils/path");
+const { StoplightParserError } = require("../../lib/util/errors");
 
 describe("Callback & Promise syntax", () => {
   for (let method of ["parse", "resolve", "dereference", "bundle"]) {
@@ -42,7 +43,7 @@ describe("Callback & Promise syntax", () => {
     return function (done) {
       $RefParser[method](path.rel("specs/invalid/invalid.yaml"), (err, result) => {
         try {
-          expect(err).to.be.an.instanceOf(SyntaxError);
+          expect(err).to.be.an.instanceOf(StoplightParserError);
           expect(result).to.be.undefined;
           done();
         }
@@ -75,7 +76,7 @@ describe("Callback & Promise syntax", () => {
       return $RefParser[method](path.rel("specs/invalid/invalid.yaml"))
         .then(helper.shouldNotGetCalled)
         .catch((err) => {
-          expect(err).to.be.an.instanceOf(SyntaxError);
+          expect(err).to.be.an.instanceOf(StoplightParserError);
         });
     };
   }

--- a/test/specs/invalid/invalid.spec.js
+++ b/test/specs/invalid/invalid.spec.js
@@ -1,10 +1,14 @@
 "use strict";
 
 const { host } = require("host-environment");
-const { expect } = require("chai");
+const chai = require("chai");
+const chaiSubset = require("chai-subset");
+chai.use(chaiSubset);
+const { expect } = chai;
 const $RefParser = require("../../../lib");
 const helper = require("../../utils/helper");
 const path = require("../../utils/path");
+const { StoplightParserError, ParserError } = require("../../../lib/util/errors");
 
 describe("Invalid syntax", () => {
   describe("in main file", () => {
@@ -28,7 +32,7 @@ describe("Invalid syntax", () => {
         helper.shouldNotGetCalled();
       }
       catch (err) {
-        expect(err).to.be.an.instanceOf(SyntaxError);
+        expect(err).to.be.an.instanceOf(StoplightParserError);
         expect(err.message).to.contain("Error parsing ");
         expect(err.message).to.contain("invalid/invalid.yaml");
       }
@@ -40,7 +44,7 @@ describe("Invalid syntax", () => {
         helper.shouldNotGetCalled();
       }
       catch (err) {
-        expect(err).to.be.an.instanceOf(SyntaxError);
+        expect(err).to.be.an.instanceOf(StoplightParserError);
         expect(err.message).to.contain("Error parsing ");
         expect(err.message).to.contain("invalid/invalid.json");
       }
@@ -52,7 +56,7 @@ describe("Invalid syntax", () => {
         helper.shouldNotGetCalled();
       }
       catch (err) {
-        expect(err).to.be.an.instanceOf(SyntaxError);
+        expect(err).to.be.an.instanceOf(StoplightParserError);
         expect(err.message).to.contain("Error parsing ");
         expect(err.message).to.contain("invalid/invalid.json");
       }
@@ -68,6 +72,53 @@ describe("Invalid syntax", () => {
         expect(err.message).to.contain('invalid/invalid.yaml" is not a valid JSON Schema');
       }
     });
+
+    describe("when failFast is false", () => {
+      it("should not throw an error for an invalid YAML file", async () => {
+        const parser = new $RefParser();
+        await parser.dereference(path.rel("specs/invalid/invalid.yaml"), { failFast: false });
+        expect(parser.errors).to.containSubset([
+          {
+            name: ParserError.name,
+            message: "incomplete explicit mapping pair; a key node is missed",
+            path: [],
+            source: expectedValue => expectedValue.endsWith("test/specs/invalid/invalid.yaml"),
+          },
+        ]);
+      });
+
+      it("should not throw an error for an invalid JSON file", async () => {
+        const parser = new $RefParser();
+        await parser.dereference(path.rel("specs/invalid/invalid.json"), { failFast: false });
+        expect(parser.errors).to.containSubset([
+          {
+            name: ParserError.name,
+            message: "unexpected end of the stream within a flow collection",
+            path: [],
+            source: expectedValue => expectedValue.endsWith("test/specs/invalid/invalid.json"),
+          }
+        ]);
+      });
+
+      it("should not throw an error for an invalid JSON file with YAML disabled", async () => {
+        const parser = new $RefParser();
+        await parser.dereference(path.rel("specs/invalid/invalid.json"), { failFast: false, parse: { yaml: false }});
+        expect(parser.errors).to.containSubset([
+          {
+            name: ParserError.name,
+            message: "CloseBraceExpected",
+            path: [],
+            source: expectedValue => expectedValue.endsWith("test/specs/invalid/invalid.json"),
+          }
+        ]);
+      });
+
+      it("should not throw an error for an invalid YAML file with JSON and YAML disabled", async () => {
+        const parser = new $RefParser();
+        await $RefParser.dereference(path.rel("specs/invalid/invalid.yaml"), { failFast: false, parse: { yaml: false, json: false }});
+        expect(parser.errors).to.deep.equal([]);
+      });
+    });
   });
 
   describe("in referenced files", () => {
@@ -77,7 +128,7 @@ describe("Invalid syntax", () => {
         helper.shouldNotGetCalled();
       }
       catch (err) {
-        expect(err).to.be.an.instanceOf(SyntaxError);
+        expect(err).to.be.an.instanceOf(StoplightParserError);
         expect(err.message).to.contain("Error parsing ");
         expect(err.message).to.contain("invalid/invalid.yaml");
       }
@@ -89,7 +140,7 @@ describe("Invalid syntax", () => {
         helper.shouldNotGetCalled();
       }
       catch (err) {
-        expect(err).to.be.an.instanceOf(SyntaxError);
+        expect(err).to.be.an.instanceOf(StoplightParserError);
         expect(err.message).to.contain("Error parsing ");
         expect(err.message).to.contain("invalid/invalid.json");
       }
@@ -103,7 +154,7 @@ describe("Invalid syntax", () => {
         helper.shouldNotGetCalled();
       }
       catch (err) {
-        expect(err).to.be.an.instanceOf(SyntaxError);
+        expect(err).to.be.an.instanceOf(StoplightParserError);
         expect(err.message).to.contain("Error parsing ");
         expect(err.message).to.contain("invalid/invalid.json");
       }

--- a/test/specs/missing-pointers/missing-pointers.spec.js
+++ b/test/specs/missing-pointers/missing-pointers.spec.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const chai = require("chai");
+const chaiSubset = require("chai-subset");
+chai.use(chaiSubset);
+const { expect } = chai;
+const $RefParser = require("../../../lib");
+const helper = require("../../utils/helper");
+const { MissingPointerError } = require("../../../lib/util/errors");
+
+describe("Schema with missing pointers", () => {
+  it("should throw an error for missing pointer", async () => {
+    try {
+      await $RefParser.dereference({ foo: { $ref: "#/baz" }});
+      helper.shouldNotGetCalled();
+    }
+    catch (err) {
+      expect(err).to.be.an.instanceOf(MissingPointerError);
+      expect(err.message).to.contain("Token \"baz\" does not exist.");
+    }
+  });
+
+  it("should not throw an error for missing pointer if failFast is false", async () => {
+    const parser = new $RefParser();
+    await parser.dereference({ foo: { $ref: "#/baz" }}, { failFast: false });
+    expect(parser.errors).to.containSubset([
+      {
+        name: MissingPointerError.name,
+        message: "Token \"baz\" does not exist.",
+        path: ["foo"],
+        source: expectedValue => expectedValue.endsWith("/test/"),
+      }
+    ]);
+  });
+});

--- a/test/specs/parsers/parsers.spec.js
+++ b/test/specs/parsers/parsers.spec.js
@@ -6,6 +6,7 @@ const helper = require("../../utils/helper");
 const path = require("../../utils/path");
 const parsedSchema = require("./parsed");
 const dereferencedSchema = require("./dereferenced");
+const { StoplightParserError } = require("../../../lib/util/errors");
 
 describe("References to non-JSON files", () => {
   it("should parse successfully", async () => {
@@ -70,7 +71,7 @@ describe("References to non-JSON files", () => {
       helper.shouldNotGetCalled();
     }
     catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(StoplightParserError);
       expect(err.message).to.contain("Error parsing ");
     }
   });

--- a/test/specs/refs.spec.js
+++ b/test/specs/refs.spec.js
@@ -216,10 +216,7 @@ describe("$Refs object", () => {
       }
       catch (err) {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal(
-          'Error resolving $ref pointer "definitions/name.yaml#/". ' +
-          '\nToken "" does not exist.'
-        );
+        expect(err.message).to.equal('Token "" does not exist.');
       }
     });
 
@@ -257,10 +254,7 @@ describe("$Refs object", () => {
       }
       catch (err) {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal(
-          'Error resolving $ref pointer "external.yaml#/foo/bar". ' +
-          '\nToken "foo" does not exist.'
-        );
+        expect(err.message).to.equal('Token "foo" does not exist.');
       }
     });
   });

--- a/test/specs/yaml.spec.js
+++ b/test/specs/yaml.spec.js
@@ -18,7 +18,7 @@ describe("YAML object", () => {
         "    type: number"
       );
 
-      expect(obj).to.deep.equal({
+      expect(obj).to.have.property("data").that.deep.equal({
         title: "person",
         required: ["name", "age"],
         properties: {
@@ -34,12 +34,12 @@ describe("YAML object", () => {
 
     it("should parse a string", async () => {
       let str = $RefParser.YAML.parse("hello, world");
-      expect(str).to.equal("hello, world");
+      expect(str).to.have.property("data", "hello, world");
     });
 
     it("should parse a number", async () => {
       let str = $RefParser.YAML.parse("42");
-      expect(str).to.be.a("number").equal(42);
+      expect(str).to.have.property("data").that.is.a("number").and.equal(42);
     });
   });
 
@@ -127,7 +127,7 @@ describe("YAML object", () => {
 
     it("should stringify a string", async () => {
       let yaml = $RefParser.YAML.stringify("hello, world");
-      expect(yaml).to.equal("'hello, world'\n");
+      expect(yaml).to.equal("hello, world");
     });
 
     it("should stringify a number", async () => {


### PR DESCRIPTION
Here is an alternative take on error handling, this time around covering exceptions thrown by resolvers.
I believe we'll want to apply the same strategy to the parsing errors as well.
I considered doing it earlier, but decided to go with "no-throw" flow, as technically our parsers do not throw exceptions and for the most of time there is some data returned we make use of.
That being said, we can change that, and simply throw an exception if diagnostics.length > 0.

Note - we don't accumulate errors here, but this will be done in the parsing PR that has `$Ref.errors`.

What do you folks think?
@marbemac @pytlesk4

I could also add that `onError` handler Tom mentioned.
Leaving the call up to you - don't have any strong preference.