### PR TITLE
fix: continueOnError behaves correctly when parsing result is empty

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -124,7 +124,7 @@ function parseFile (file, options, $refs) {
       .then(onParsed, onError);
 
     function onParsed (parser) {
-      if ((options.continueOnError || !parser.plugin.allowEmpty) && isEmpty(parser.result)) {
+      if (!options.continueOnError && !parser.plugin.allowEmpty && isEmpty(parser.result)) {
         reject(ono.syntax(`Error parsing "${file.url}" as ${parser.plugin.name}. \nParsed value is empty`));
       }
       else {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -124,7 +124,7 @@ function parseFile (file, options, $refs) {
       .then(onParsed, onError);
 
     function onParsed (parser) {
-      if (!options.continueOnError && !parser.plugin.allowEmpty && isEmpty(parser.result)) {
+      if (!parser.plugin.allowEmpty && isEmpty(parser.result)) {
         reject(ono.syntax(`Error parsing "${file.url}" as ${parser.plugin.name}. \nParsed value is empty`));
       }
       else {

--- a/test/specs/parsers/parsers.spec.js
+++ b/test/specs/parsers/parsers.spec.js
@@ -206,7 +206,7 @@ describe("References to non-JSON files", () => {
     }
   });
 
-  it("should throw a grouped error if no parser can be matched and fastFail is false", async () => {
+  it("should throw a grouped error if no parser can be matched and continueOnError is true", async () => {
     try {
       const parser = new $RefParser();
       await parser.dereference(path.rel("specs/parsers/parsers.yaml"), {


### PR DESCRIPTION
Fixes condition which controls rejection of empty parsing result.

`continueOnError has to be false` and `allowEmpty has to be false` in order for the empty result to cause rejection


This fixes https://github.com/stoplightio/platform-internal/issues/2822