### PR TITLE
StoplightKeyGenerator should defer access of gen opts

### DIFF
--- a/lib/bundle/stoplight-defaults.js
+++ b/lib/bundle/stoplight-defaults.js
@@ -10,11 +10,9 @@ const {
 const { parse, isHttp, isFileSystemPath } = require("../util/url");
 const KeyGenerator = require("./util/key-generator");
 
-function StoplightKeyGenerator (root, { cwd, endpointUrl, srn }) {
+function StoplightKeyGenerator (root, opts) {
   KeyGenerator.call(this, root);
-  this._cwd = cwd;
-  this._endpointUrl = endpointUrl;
-  this._srn = srn;
+  this._opts = opts;
 }
 
 StoplightKeyGenerator.prototype = Object.create(KeyGenerator.prototype, {
@@ -30,15 +28,18 @@ StoplightKeyGenerator.prototype.processPath = function (path) {
     return this.extractFilepathFromUrl(path);
   }
 
-  if (isFileSystemPath(path) && this._srn !== null && path.indexOf(this._cwd) === 0) {
+  let { srn, cwd } = this._opts;
+
+  if (srn !== null && cwd !== null && isFileSystemPath(path) && path.indexOf(cwd) === 0) {
     // filesystem, file in the same project
-    return join(this._srn, stripRoot(path.slice(this._cwd.length)));
+    return join(srn, stripRoot(path.slice(cwd.length)));
   }
 
   return path;
 };
 
 StoplightKeyGenerator.prototype.extractFilepathFromUrl = function (url) {
+  let { endpointUrl } = this._opts;
   let { href, query } = parse(url, true);
 
   let mid = query.mid ? `_m${query.mid}` : "";
@@ -48,9 +49,9 @@ StoplightKeyGenerator.prototype.extractFilepathFromUrl = function (url) {
     return query.srn + mid;
   }
 
-  if (href.indexOf(this._endpointUrl) === 0) {
+  if (endpointUrl !== null && href.indexOf(endpointUrl) === 0) {
     // this is for v2
-    return href.slice(this._endpointUrl.length) + mid;
+    return href.slice(endpointUrl.length) + mid;
   }
 
   return url;
@@ -119,9 +120,7 @@ StoplightKeyGenerator.prototype.generateKeyForUrl = function (schema, url) {
   return KeyGenerator.prototype.generateKeyForUrl.call(this, schema, url);
 };
 
-module.exports = function (cwd, endpointUrl, srn) {
-  let opts = { cwd, endpointUrl, srn };
-
+module.exports = function (opts) {
   return {
     get oas2 () {
       return getDefaultsForOAS2(getGenericDefaults(new StoplightKeyGenerator("#/definitions", opts)));

--- a/test/specs/custom-bundling-roots/custom-roots.spec.js
+++ b/test/specs/custom-bundling-roots/custom-roots.spec.js
@@ -206,7 +206,11 @@ describe("Custom bundling roots", () => {
       });
 
       it("should allow to customize bundling roots for OAS2", async () => {
-        const defaults = createStoplightDefaults(__dirname, "http://localhost:8080/api/nodes.raw/", "gh/stoplightio/test");
+        let defaults = createStoplightDefaults({
+          cwd: __dirname,
+          endpointUrl: "http://localhost:8080/api/nodes.raw/",
+          srn: "gh/stoplightio/test"
+        });
         let parser = new $RefParser();
 
         const schema = await parser.bundle(path.rel("specs/custom-bundling-roots/reference/openapi-2.json"), {
@@ -218,7 +222,11 @@ describe("Custom bundling roots", () => {
       });
 
       it("should allow to customize bundling roots for OAS3", async () => {
-        const defaults = createStoplightDefaults(__dirname, "http://localhost:8080/api/nodes.raw/", "gh/stoplightio/test");
+        let defaults = createStoplightDefaults({
+          cwd: __dirname,
+          endpointUrl: "http://localhost:8080/api/nodes.raw/",
+          srn: "gh/stoplightio/test"
+        });
         let parser = new $RefParser();
 
         const schema = await parser.bundle(path.rel("specs/custom-bundling-roots/reference/openapi-3.json"), {
@@ -231,7 +239,11 @@ describe("Custom bundling roots", () => {
     });
 
     it("given no collision, should not append mid to the key", async () => {
-      const defaults = createStoplightDefaults(__dirname, "http://localhost:8080/api/nodes.raw/", "gh/stoplightio/test");
+      let defaults = createStoplightDefaults({
+        cwd: __dirname,
+        endpointUrl: "http://localhost:8080/api/nodes.raw/",
+        srn: "gh/stoplightio/test"
+      });
       nock("http://localhost:8080")
         .get("/api/nodes.raw/")
         .query({
@@ -286,8 +298,11 @@ describe("Custom bundling roots", () => {
     });
 
     it("given collision, should append mid to the key", async () => {
-      const defaults = createStoplightDefaults(__dirname, "http://localhost:8080/api/nodes.raw/", "gh/stoplightio/test");
-
+      let defaults = createStoplightDefaults({
+        cwd: __dirname,
+        endpointUrl: "http://localhost:8080/api/nodes.raw/",
+        srn: "gh/stoplightio/test"
+      });
       nock("http://localhost:8080")
         .get("/api/nodes.raw/")
         .query({
@@ -393,7 +408,11 @@ describe("Custom bundling roots", () => {
     });
 
     it("should recognize v1 & v2 references", async () => {
-      const defaults = createStoplightDefaults(__dirname, "https://example.com/api/nodes.raw/", "org/proj/data-model-dictionary");
+      let defaults = createStoplightDefaults({
+        cwd: __dirname,
+        endpointUrl: "https://example.com/api/nodes.raw/",
+        srn: "org/proj/data-model-dictionary"
+      });
       nock("https://example.com")
         .get("/api/nodes.raw/")
         .query({


### PR DESCRIPTION
This is essential for https://github.com/stoplightio/platform-internal/pull/4805