### PR TITLE
Arbitrary urls

### DIFF
--- a/lib/bundle/stoplight-defaults.js
+++ b/lib/bundle/stoplight-defaults.js
@@ -117,7 +117,7 @@ StoplightKeyGenerator.prototype.generateKeyForUrl = function (schema, url) {
     //
   }
 
-  return KeyGenerator.prototype.generateKeyForUrl.call(this, schema, url);
+  return null;
 };
 
 module.exports = function (opts) {

--- a/lib/bundle/stoplight-defaults.js
+++ b/lib/bundle/stoplight-defaults.js
@@ -39,19 +39,24 @@ StoplightKeyGenerator.prototype.processPath = function (path) {
 };
 
 StoplightKeyGenerator.prototype.extractFilepathFromUrl = function (url) {
-  let { endpointUrl } = this._opts;
+  let { endpointUrl, cwd } = this._opts;
   let { href, query } = parse(url, true);
 
   let mid = query.mid ? `_m${query.mid}` : "";
 
   if (typeof query.srn === "string") {
-    // this is for v1
+    // this is for v1 (srn)
     return query.srn + mid;
   }
 
   if (endpointUrl !== null && href.indexOf(endpointUrl) === 0) {
-    // this is for v2
+    // this is for v1 (href)
     return href.slice(endpointUrl.length) + mid;
+  }
+
+  // this is mostly for the sake of Karma... but might be useful for us, one day. Perhaps.
+  if (cwd !== null && isHttp(cwd) && href.indexOf(cwd) === 0) {
+    return href.slice(cwd.length);
   }
 
   return url;

--- a/lib/bundle/util/key-generator.js
+++ b/lib/bundle/util/key-generator.js
@@ -97,10 +97,17 @@ Object.assign(KeyGenerator.prototype, {
 
   registerNewGeneratedKey (schema, id, key) {
     let generatedKeys = this.getGeneratedKeys(schema);
-    let takenKeys = this.getTakenKeys(schema);
 
-    takenKeys.add(key);
-    generatedKeys[id] = `${this.root}/${key}`;
+    if (key === null) {
+      generatedKeys[id] = key;
+    }
+    else {
+      let takenKeys = this.getTakenKeys(schema);
+
+      takenKeys.add(key);
+      generatedKeys[id] = `${this.root}/${key}`;
+    }
+
     return generatedKeys[id];
   },
 
@@ -125,7 +132,7 @@ Object.assign(KeyGenerator.prototype, {
   generateKeyForUrl (schema, url) {
     if (!this.hasExistingGeneratedKey(schema, url)) {
       let { path } = parse(url, true);
-      let key = this.generateUniqueKey(schema, this.getPrettifiedKeyForFilepath(path));
+      let key = path === "/" ? null : this.generateUniqueKey(schema, this.getPrettifiedKeyForFilepath(path));
 
       this.registerNewGeneratedKey(schema, url, key);
     }

--- a/test/specs/custom-bundling-roots/custom-roots.spec.js
+++ b/test/specs/custom-bundling-roots/custom-roots.spec.js
@@ -8,6 +8,8 @@ const setupHttpMocks = require("../../utils/setup-http-mocks");
 const { getDefaultsForOldJsonSchema, getDefaultsForOAS2 } = require("../../../lib/bundle/defaults");
 const createStoplightDefaults = require("../../../lib/bundle/stoplight-defaults");
 
+const cwd = typeof window === "object" ? location.origin + "/base/test/specs/custom-bundling-roots" : __dirname;
+
 describe("Custom bundling roots", () => {
   it("mixed inline", async () => {
     let parser = new $RefParser();
@@ -179,7 +181,7 @@ describe("Custom bundling roots", () => {
 
   it("given arbitrary URL, should not attempt to generate pretty key", async () => {
     let defaults = createStoplightDefaults({
-      cwd: __dirname,
+      cwd,
       endpointUrl: "http://localhost:8080/api/nodes.raw/",
       srn: "gh/stoplightio/test"
     });
@@ -242,7 +244,7 @@ describe("Custom bundling roots", () => {
         });
 
         defaults = createStoplightDefaults({
-          cwd: __dirname,
+          cwd,
           endpointUrl: "http://localhost:8080/api/nodes.raw/",
           srn: "gh/stoplightio/test"
         });
@@ -273,7 +275,7 @@ describe("Custom bundling roots", () => {
 
     it("given no collision, should not append mid to the key", async () => {
       let defaults = createStoplightDefaults({
-        cwd: __dirname,
+        cwd,
         endpointUrl: "http://localhost:8080/api/nodes.raw/",
         srn: "gh/stoplightio/test"
       });
@@ -329,7 +331,7 @@ describe("Custom bundling roots", () => {
 
     it("given collision, should append mid to the key", async () => {
       let defaults = createStoplightDefaults({
-        cwd: __dirname,
+        cwd,
         endpointUrl: "http://localhost:8080/api/nodes.raw/",
         srn: "gh/stoplightio/test"
       });
@@ -407,7 +409,7 @@ describe("Custom bundling roots", () => {
 
     it("should recognize v1 & v2 references", async () => {
       let defaults = createStoplightDefaults({
-        cwd: __dirname,
+        cwd,
         endpointUrl: "https://example.com/api/nodes.raw/",
         srn: "org/proj/data-model-dictionary"
       });


### PR DESCRIPTION
I noticed we had a minor inconsistency with the [spec](https://github.com/stoplightio/platform-internal/issues/4468)

> Arbitrary URL refs (non design library) will be bundled with the same strategy as today (inlined).

This PR makes the key generator consider all non-Stoplight URLs as generic. That way, no custom root will be defined for such a URL.