### PR TITLE
Bundling support for other shared components 

### DIFF
--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -122,7 +122,7 @@ module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new 
         !canReferenceSchema(pathParsed) &&
         !canReferenceParameter(pathParsed) &&
         !canReferenceResponse(pathParsed) &&
-        !canReferenceRequestBody(pathParsed) && 
+        !canReferenceRequestBody(pathParsed) &&
         !canReferenceHeader(pathParsed)
       ) {
         return null;
@@ -147,7 +147,7 @@ function normalizeOasSchemasHash (hash, root) {
     "#/definitions",
     "#/responses",
     "#/parameters",
-  ].reduce((currHash, prefix) => currHash.replace(prefix, ''), hash);
+  ].reduce((currHash, prefix) => currHash.replace(prefix, ""), hash);
 
   return root + strippedHash;
 }

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -53,10 +53,12 @@ module.exports.getDefaultsForNewJsonSchema = function (defaults = getGenericDefa
 };
 
 const defaultOas2RootResolver = (pathFromRoot) => {
-  if (pathFromRoot && isParameterPlacement(pathFromRoot.split("/"))) {
+  const pathParsed = pathFromRoot.split("/");
+
+  if (canReferenceParameter(pathParsed)) {
     return "#/parameters";
   }
-  if (pathFromRoot && isResponsePlacement(pathFromRoot.split("/"))) {
+  if (canReferenceResponse(pathParsed)) {
     return "#/responses";
   }
 
@@ -64,11 +66,16 @@ const defaultOas2RootResolver = (pathFromRoot) => {
 };
 
 const defaultOas3RootResolver = (pathFromRoot) => {
-  if (pathFromRoot && isParameterPlacement(pathFromRoot.split("/"))) {
+  const pathParsed = pathFromRoot.split("/");
+
+  if (canReferenceParameter(pathParsed)) {
     return "#/components/parameters";
   }
-  if (pathFromRoot && isResponsePlacement(pathFromRoot.split("/"))) {
+  if (canReferenceResponse(pathParsed)) {
     return "#/components/responses";
+  }
+  if (canReferenceRequestBody(pathParsed)) {
+    return "#/components/requestBodies";
   }
 
   return "#/components/schemas";
@@ -77,15 +84,15 @@ const defaultOas3RootResolver = (pathFromRoot) => {
 module.exports.defaultOas2RootResolver = defaultOas2RootResolver;
 module.exports.defaultOas3RootResolver = defaultOas3RootResolver;
 
-module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new KeyGenerator(defaultOas2RootResolver))) {
+module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new KeyGenerator(module.exports.defaultOas2RootResolver))) {
   return {
     ...defaults,
     generateKey (schema, file, hash, pathFromRoot) {
       if (
         !pathFromRoot.startsWith(defaults.defaultRoot(pathFromRoot)) &&
-        !isSchemaPlacement(pathFromRoot.split("/")) &&
-        !isParameterPlacement(pathFromRoot.split("/")) &&
-        !isResponsePlacement(pathFromRoot.split("/"))
+        !canReferenceSchema(pathFromRoot.split("/")) &&
+        !canReferenceParameter(pathFromRoot.split("/")) &&
+        !canReferenceResponse(pathFromRoot.split("/"))
       ) {
         return null;
       }
@@ -100,41 +107,68 @@ module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new 
 };
 
 module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new KeyGenerator(defaultOas3RootResolver))) {
-  return module.exports.getDefaultsForOAS2(defaults);
+  return {
+    ...defaults,
+    generateKey (schema, file, hash, pathFromRoot) {
+      if (
+        !pathFromRoot.startsWith(defaults.defaultRoot(pathFromRoot)) &&
+        !canReferenceSchema(pathFromRoot.split("/")) &&
+        !canReferenceParameter(pathFromRoot.split("/")) &&
+        !canReferenceResponse(pathFromRoot.split("/")) &&
+        !canReferenceRequestBody(pathFromRoot.split("/"))
+      ) {
+        return null;
+      }
+
+      if (hash !== "#" && hash !== null) {
+        return defaults.generateKey(schema, file, normalizeOasSchemasHash(hash, defaults.defaultRoot(pathFromRoot)), pathFromRoot);
+      }
+
+      return defaults.generateKey(schema, file, hash, pathFromRoot);
+    },
+  };
 };
 
 function normalizeOasSchemasHash (hash, root) {
   return hash.replace(/\/(?:components\/schemas|definitions)\//g, root.slice(1) + "/");
 }
 
-// this should return true for every place in a OAS document that can reference a JSON Schema model
-function isSchemaPlacement (path) {
-  if (isInOasOperation(path) && path.includes("schema")) {
+function canReferenceSchema (path) {
+  if (path.length > 3 && path[1] === "paths" && path.includes("schema")) {
     return true;
   }
 
   return false;
 }
 
-// this should return true for every place in a OAS document that can reference a parameter
-function isParameterPlacement (path) {
-  if (isInOasOperation(path) && path.includes("parameters")) {
+function canReferenceParameter (path) {
+  // #/paths/pathName/parameters/0
+  if (path.length === 5 && path[1] === "paths" && path[3] === "parameters") {
+    return true;
+  }
+
+  // #/paths/pathName/pathMethod/parameters/0
+  if (path.length === 6 && path[1] === "paths" && path[4] === "parameters") {
     return true;
   }
 
   return false;
 }
 
-// this should return true for every place in a OAS document that can reference a response
-function isResponsePlacement (path) {
-  if (isInOasOperation(path) && path[path.length - 2] === "responses") {
+function canReferenceResponse (path) {
+  // #/paths/pathName/pathMethod/responses/statusCode
+  if (path.length === 6 && path[1] === "paths" && path[4] === "responses") {
     return true;
   }
 
   return false;
 }
 
+function canReferenceRequestBody (path) {
+  // #/paths/pathName/pathMethod/requestBody
+  if (path.length === 5 && path[1] === "paths" && path[4] === "requestBody") {
+    return true;
+  }
 
-function isInOasOperation (path) {
-  return path.length > 3 && path[1] === "paths";
+  return false;
 }

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -34,7 +34,7 @@ function getGenericDefaults (generator) {
       }
 
       if (url.isHttp(file)) {
-        return generator.generateKeyForUrl(schema, file);
+        return generator.generateKeyForUrl(schema, file, pathFromRoot);
       }
 
       return generator.generateKeyForFilepath(schema, file);
@@ -44,26 +44,26 @@ function getGenericDefaults (generator) {
 
 module.exports.getGenericDefaults = getGenericDefaults;
 
-module.exports.getDefaultsForOldJsonSchema = function (defaults = getGenericDefaults(new KeyGenerator("#/definitions"))) {
+module.exports.getDefaultsForOldJsonSchema = function (defaults = getGenericDefaults(new KeyGenerator(() => "#/definitions"))) {
   return defaults;
 };
 
-module.exports.getDefaultsForNewJsonSchema = function (defaults = getGenericDefaults(new KeyGenerator("#/$defs"))) {
+module.exports.getDefaultsForNewJsonSchema = function (defaults = getGenericDefaults(new KeyGenerator(() => "#/$defs"))) {
   return defaults;
 };
 
-module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new KeyGenerator("#/definitions"))) {
+module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new KeyGenerator(() => "#/definitions"))) {
   return {
     ...defaults,
     generateKey (schema, file, hash, pathFromRoot) {
-      pathFromRoot = normalizeOasSchemasHash(pathFromRoot, defaults.defaultRoot);
+      pathFromRoot = normalizeOasSchemasHash(pathFromRoot, defaults.defaultRoot(pathFromRoot));
 
-      if (!pathFromRoot.startsWith(defaults.defaultRoot) && !isSchemaPlacement(pathFromRoot.split("/"))) {
+      if (!pathFromRoot.startsWith(defaults.defaultRoot(pathFromRoot)) && !isSchemaPlacement(pathFromRoot.split("/"))) {
         return null;
       }
 
       if (hash !== "#" && hash !== null) {
-        return defaults.generateKey(schema, file, normalizeOasSchemasHash(hash, defaults.defaultRoot), pathFromRoot);
+        return defaults.generateKey(schema, file, normalizeOasSchemasHash(hash, defaults.defaultRoot(pathFromRoot)), pathFromRoot);
       }
 
       return defaults.generateKey(schema, file, hash, pathFromRoot);
@@ -71,7 +71,7 @@ module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new 
   };
 };
 
-module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new KeyGenerator("#/components/schemas"))) {
+module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new KeyGenerator(() => "#/components/schemas"))) {
   return module.exports.getDefaultsForOAS2(defaults);
 };
 

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -64,6 +64,8 @@ const defaultOas2RootResolver = (pathFromRoot) => {
   if (canReferenceSchema(pathParsed)) {
     return "#/definitions";
   }
+
+  return null;
 };
 
 const defaultOas3RootResolver = (pathFromRoot) => {
@@ -82,8 +84,10 @@ const defaultOas3RootResolver = (pathFromRoot) => {
     return "#/components/headers";
   }
   if (canReferenceSchema(pathParsed)) {
-    return "#/components/schemas"
+    return "#/components/schemas";
   }
+
+  return null;
 };
 
 module.exports.defaultOas2RootResolver = defaultOas2RootResolver;
@@ -156,9 +160,9 @@ function normalizeOasSchemasHash (hash, root) {
 
 function canReferenceSchema (path) {
   return (
-    (path.length > 3 && path[1] === "paths" && path.includes("schema")) || 
-    (path[1] === 'components' && path[2] === 'schemas') || // oas2 schema referencing schema
-    (path[1] === 'definitions')  // oas3 schema referencing schema
+    (path.length > 3 && path[1] === "paths" && path.includes("schema")) ||
+    (path[1] === "components" && path[2] === "schemas") || // oas2 schema referencing schema
+    (path[1] === "definitions")  // oas3 schema referencing schema
   );
 }
 

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -61,8 +61,9 @@ const defaultOas2RootResolver = (pathFromRoot) => {
   if (canReferenceResponse(pathParsed)) {
     return "#/responses";
   }
-
-  return "#/definitions";
+  if (canReferenceSchema(pathParsed)) {
+    return "#/definitions";
+  }
 };
 
 const defaultOas3RootResolver = (pathFromRoot) => {
@@ -80,8 +81,9 @@ const defaultOas3RootResolver = (pathFromRoot) => {
   if (canReferenceHeader(pathParsed)) {
     return "#/components/headers";
   }
-
-  return "#/components/schemas";
+  if (canReferenceSchema(pathParsed)) {
+    return "#/components/schemas"
+  }
 };
 
 module.exports.defaultOas2RootResolver = defaultOas2RootResolver;
@@ -153,7 +155,11 @@ function normalizeOasSchemasHash (hash, root) {
 }
 
 function canReferenceSchema (path) {
-  return path.length > 3 && path[1] === "paths" && path.includes("schema");
+  return (
+    (path.length > 3 && path[1] === "paths" && path.includes("schema")) || 
+    (path[1] === 'components' && path[2] === 'schemas') || // oas2 schema referencing schema
+    (path[1] === 'definitions')  // oas3 schema referencing schema
+  );
 }
 
 function canReferenceParameter (path) {

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -108,10 +108,6 @@ module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new 
         return null;
       }
 
-      if (hash !== "#" && hash !== null) {
-        return defaults.generateKey(schema, file, normalizeOasSchemasHash(hash, defaults.defaultRoot(pathFromRoot)), pathFromRoot);
-      }
-
       return defaults.generateKey(schema, file, hash, pathFromRoot);
     },
   };
@@ -134,29 +130,10 @@ module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new 
         return null;
       }
 
-      if (hash !== "#" && hash !== null) {
-        return defaults.generateKey(schema, file, normalizeOasSchemasHash(hash, defaults.defaultRoot(pathFromRoot)), pathFromRoot);
-      }
-
       return defaults.generateKey(schema, file, hash, pathFromRoot);
     },
   };
 };
-
-function normalizeOasSchemasHash (hash, root) {
-  const strippedHash = [
-    "#/components/schemas",
-    "#/components/parameters",
-    "#/components/responses",
-    "#/components/requestBodies",
-    "#/components/headers",
-    "#/definitions",
-    "#/responses",
-    "#/parameters",
-  ].reduce((currHash, prefix) => currHash.replace(prefix, ""), hash);
-
-  return root + strippedHash;
-}
 
 function canReferenceSchema (path) {
   return (

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -77,6 +77,9 @@ const defaultOas3RootResolver = (pathFromRoot) => {
   if (canReferenceRequestBody(pathParsed)) {
     return "#/components/requestBodies";
   }
+  if (canReferenceHeader(pathParsed)) {
+    return "#/components/headers";
+  }
 
   return "#/components/schemas";
 };
@@ -88,11 +91,13 @@ module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new 
   return {
     ...defaults,
     generateKey (schema, file, hash, pathFromRoot) {
+      const pathParsed = pathFromRoot.split("/");
+
       if (
         !pathFromRoot.startsWith(defaults.defaultRoot(pathFromRoot)) &&
-        !canReferenceSchema(pathFromRoot.split("/")) &&
-        !canReferenceParameter(pathFromRoot.split("/")) &&
-        !canReferenceResponse(pathFromRoot.split("/"))
+        !canReferenceSchema(pathParsed) &&
+        !canReferenceParameter(pathParsed) &&
+        !canReferenceResponse(pathParsed)
       ) {
         return null;
       }
@@ -110,12 +115,15 @@ module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new 
   return {
     ...defaults,
     generateKey (schema, file, hash, pathFromRoot) {
+      const pathParsed = pathFromRoot.split("/");
+
       if (
         !pathFromRoot.startsWith(defaults.defaultRoot(pathFromRoot)) &&
-        !canReferenceSchema(pathFromRoot.split("/")) &&
-        !canReferenceParameter(pathFromRoot.split("/")) &&
-        !canReferenceResponse(pathFromRoot.split("/")) &&
-        !canReferenceRequestBody(pathFromRoot.split("/"))
+        !canReferenceSchema(pathParsed) &&
+        !canReferenceParameter(pathParsed) &&
+        !canReferenceResponse(pathParsed) &&
+        !canReferenceRequestBody(pathParsed) && 
+        !canReferenceHeader(pathParsed)
       ) {
         return null;
       }
@@ -135,6 +143,7 @@ function normalizeOasSchemasHash (hash, root) {
     "#/components/parameters",
     "#/components/responses",
     "#/components/requestBodies",
+    "#/components/headers",
     "#/definitions",
     "#/responses",
     "#/parameters",
@@ -164,4 +173,9 @@ function canReferenceResponse (path) {
 function canReferenceRequestBody (path) {
   // [#, paths, pathName, pathMethod, requestBody]
   return path.length === 5 && path[1] === "paths" && path[4] === "requestBody";
+}
+
+function canReferenceHeader (path) {
+  // [#, paths, pathName, pathMethod, responses, statusCode, headers, headerName]
+  return path.length === 8 && path[1] === "paths" && path[4] === "responses" && path[6] === "headers";
 }

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -130,7 +130,17 @@ module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new 
 };
 
 function normalizeOasSchemasHash (hash, root) {
-  return hash.replace(/\/(?:components\/schemas|definitions)\//g, root.slice(1) + "/");
+  const strippedHash = [
+    "#/components/schemas",
+    "#/components/parameters",
+    "#/components/responses",
+    "#/components/requestBodies",
+    "#/definitions",
+    "#/responses",
+    "#/parameters",
+  ].reduce((currHash, prefix) => currHash.replace(prefix, ''), hash);
+
+  return root + strippedHash;
 }
 
 function canReferenceSchema (path) {

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -7,7 +7,7 @@ function getGenericDefaults (generator) {
     defaultRoot: generator.root,
 
     generateKey (schema, file, hash, pathFromRoot) {
-      if (generator.isUnderDirectRoot(pathFromRoot)) {
+      if (generator.isUnderDirectRoot(pathFromRoot, pathFromRoot)) {
         return null;
       }
 
@@ -19,25 +19,25 @@ function getGenericDefaults (generator) {
         let existingGeneratedKey = generator.getExistingGeneratedKey(schema, file);
 
         if (existingGeneratedKey === undefined) {
-          existingGeneratedKey = generator.generateKeyForFilepath(schema, file);
+          existingGeneratedKey = generator.generateKeyForFilepath(schema, file, pathFromRoot);
         }
 
         if (existingGeneratedKey === null) {
           return null;
         }
 
-        if (!generator.isInRoot(hash)) {
+        if (!generator.isInRoot(hash, pathFromRoot)) {
           return null;
         }
 
-        return generator.generateKeyForPointer(schema, existingGeneratedKey + hash.slice(1));
+        return generator.generateKeyForPointer(schema, existingGeneratedKey + hash.slice(1), pathFromRoot);
       }
 
       if (url.isHttp(file)) {
         return generator.generateKeyForUrl(schema, file, pathFromRoot);
       }
 
-      return generator.generateKeyForFilepath(schema, file);
+      return generator.generateKeyForFilepath(schema, file, pathFromRoot);
     },
   };
 }

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -7,7 +7,7 @@ function getGenericDefaults (generator) {
     defaultRoot: generator.root,
 
     generateKey (schema, file, hash, pathFromRoot) {
-      if (generator.isUnderDirectRoot(pathFromRoot, pathFromRoot)) {
+      if (generator.isUnderDirectRoot(pathFromRoot)) {
         return null;
       }
 
@@ -56,6 +56,9 @@ const defaultOas2RootResolver = (pathFromRoot) => {
   if (pathFromRoot && isParameterPlacement(pathFromRoot.split("/"))) {
     return "#/parameters";
   }
+  if (pathFromRoot && isResponsePlacement(pathFromRoot.split("/"))) {
+    return "#/responses";
+  }
 
   return "#/definitions";
 };
@@ -63,6 +66,9 @@ const defaultOas2RootResolver = (pathFromRoot) => {
 const defaultOas3RootResolver = (pathFromRoot) => {
   if (pathFromRoot && isParameterPlacement(pathFromRoot.split("/"))) {
     return "#/components/parameters";
+  }
+  if (pathFromRoot && isResponsePlacement(pathFromRoot.split("/"))) {
+    return "#/components/responses";
   }
 
   return "#/components/schemas";
@@ -75,12 +81,11 @@ module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new 
   return {
     ...defaults,
     generateKey (schema, file, hash, pathFromRoot) {
-      pathFromRoot = normalizeOasSchemasHash(pathFromRoot, defaults.defaultRoot(pathFromRoot));
-
       if (
         !pathFromRoot.startsWith(defaults.defaultRoot(pathFromRoot)) &&
         !isSchemaPlacement(pathFromRoot.split("/")) &&
-        !isParameterPlacement(pathFromRoot.split("/"))
+        !isParameterPlacement(pathFromRoot.split("/")) &&
+        !isResponsePlacement(pathFromRoot.split("/"))
       ) {
         return null;
       }
@@ -119,6 +124,16 @@ function isParameterPlacement (path) {
 
   return false;
 }
+
+// this should return true for every place in a OAS document that can reference a response
+function isResponsePlacement (path) {
+  if (isInOasOperation(path) && path[path.length - 2] === "responses") {
+    return true;
+  }
+
+  return false;
+}
+
 
 function isInOasOperation (path) {
   return path.length > 3 && path[1] === "paths";

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -134,41 +134,24 @@ function normalizeOasSchemasHash (hash, root) {
 }
 
 function canReferenceSchema (path) {
-  if (path.length > 3 && path[1] === "paths" && path.includes("schema")) {
-    return true;
-  }
-
-  return false;
+  return path.length > 3 && path[1] === "paths" && path.includes("schema");
 }
 
 function canReferenceParameter (path) {
-  // #/paths/pathName/parameters/0
-  if (path.length === 5 && path[1] === "paths" && path[3] === "parameters") {
-    return true;
-  }
-
-  // #/paths/pathName/pathMethod/parameters/0
-  if (path.length === 6 && path[1] === "paths" && path[4] === "parameters") {
-    return true;
-  }
-
-  return false;
+  return (
+    // [#, paths, pathName, parameters, 0]
+    (path.length === 5 && path[1] === "paths" && path[3] === "parameters") ||
+    // [#, paths, pathName, pathMethod, parameters, 0]
+    (path.length === 6 && path[1] === "paths" && path[4] === "parameters")
+  );
 }
 
 function canReferenceResponse (path) {
-  // #/paths/pathName/pathMethod/responses/statusCode
-  if (path.length === 6 && path[1] === "paths" && path[4] === "responses") {
-    return true;
-  }
-
-  return false;
+  // [#, paths, pathName, pathMethod, responses, statusCode]
+  return path.length === 6 && path[1] === "paths" && path[4] === "responses";
 }
 
 function canReferenceRequestBody (path) {
-  // #/paths/pathName/pathMethod/requestBody
-  if (path.length === 5 && path[1] === "paths" && path[4] === "requestBody") {
-    return true;
-  }
-
-  return false;
+  // [#, paths, pathName, pathMethod, requestBody]
+  return path.length === 5 && path[1] === "paths" && path[4] === "requestBody";
 }

--- a/lib/bundle/defaults.js
+++ b/lib/bundle/defaults.js
@@ -52,13 +52,36 @@ module.exports.getDefaultsForNewJsonSchema = function (defaults = getGenericDefa
   return defaults;
 };
 
-module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new KeyGenerator(() => "#/definitions"))) {
+const defaultOas2RootResolver = (pathFromRoot) => {
+  if (pathFromRoot && isParameterPlacement(pathFromRoot.split("/"))) {
+    return "#/parameters";
+  }
+
+  return "#/definitions";
+};
+
+const defaultOas3RootResolver = (pathFromRoot) => {
+  if (pathFromRoot && isParameterPlacement(pathFromRoot.split("/"))) {
+    return "#/components/parameters";
+  }
+
+  return "#/components/schemas";
+};
+
+module.exports.defaultOas2RootResolver = defaultOas2RootResolver;
+module.exports.defaultOas3RootResolver = defaultOas3RootResolver;
+
+module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new KeyGenerator(defaultOas2RootResolver))) {
   return {
     ...defaults,
     generateKey (schema, file, hash, pathFromRoot) {
       pathFromRoot = normalizeOasSchemasHash(pathFromRoot, defaults.defaultRoot(pathFromRoot));
 
-      if (!pathFromRoot.startsWith(defaults.defaultRoot(pathFromRoot)) && !isSchemaPlacement(pathFromRoot.split("/"))) {
+      if (
+        !pathFromRoot.startsWith(defaults.defaultRoot(pathFromRoot)) &&
+        !isSchemaPlacement(pathFromRoot.split("/")) &&
+        !isParameterPlacement(pathFromRoot.split("/"))
+      ) {
         return null;
       }
 
@@ -71,7 +94,7 @@ module.exports.getDefaultsForOAS2 = function (defaults = getGenericDefaults(new 
   };
 };
 
-module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new KeyGenerator(() => "#/components/schemas"))) {
+module.exports.getDefaultsForOAS3 = function (defaults = getGenericDefaults(new KeyGenerator(defaultOas3RootResolver))) {
   return module.exports.getDefaultsForOAS2(defaults);
 };
 
@@ -82,6 +105,15 @@ function normalizeOasSchemasHash (hash, root) {
 // this should return true for every place in a OAS document that can reference a JSON Schema model
 function isSchemaPlacement (path) {
   if (isInOasOperation(path) && path.includes("schema")) {
+    return true;
+  }
+
+  return false;
+}
+
+// this should return true for every place in a OAS document that can reference a parameter
+function isParameterPlacement (path) {
+  if (isInOasOperation(path) && path.includes("parameters")) {
     return true;
   }
 

--- a/lib/bundle/stoplight/defaults.js
+++ b/lib/bundle/stoplight/defaults.js
@@ -11,14 +11,14 @@ const StoplightKeyGenerator = require("./generator");
 module.exports = function (opts) {
   return {
     get oas2 () {
-      return getDefaultsForOAS2(getGenericDefaults(new StoplightKeyGenerator("#/definitions", opts)));
+      return getDefaultsForOAS2(getGenericDefaults(new StoplightKeyGenerator(() => "#/definitions", opts)));
     },
     get oas3 () {
-      return getDefaultsForOAS3(getGenericDefaults(new StoplightKeyGenerator("#/components/schemas", opts)));
+      return getDefaultsForOAS3(getGenericDefaults(new StoplightKeyGenerator(() => "#/components/schemas", opts)));
     },
     // eslint-disable-next-line camelcase
     get json_schema () {
-      return getDefaultsForOldJsonSchema(getGenericDefaults(new StoplightKeyGenerator("#/definitions", opts)));
+      return getDefaultsForOldJsonSchema(getGenericDefaults(new StoplightKeyGenerator(() => "#/definitions", opts)));
     },
   };
 };

--- a/lib/bundle/stoplight/defaults.js
+++ b/lib/bundle/stoplight/defaults.js
@@ -20,7 +20,7 @@ module.exports = function (opts) {
     },
     // eslint-disable-next-line camelcase
     get json_schema () {
-      return getDefaultsForOldJsonSchema(getGenericDefaults(new StoplightKeyGenerator(() => "#/definitions", opts)));
+      return getDefaultsForOldJsonSchema(getGenericDefaults(new StoplightKeyGenerator("#/definitions", opts)));
     },
   };
 };

--- a/lib/bundle/stoplight/defaults.js
+++ b/lib/bundle/stoplight/defaults.js
@@ -5,16 +5,18 @@ const {
   getDefaultsForOldJsonSchema,
   getDefaultsForOAS2,
   getDefaultsForOAS3,
+  defaultOas2RootResolver,
+  defaultOas3RootResolver
 } = require("../defaults");
 const StoplightKeyGenerator = require("./generator");
 
 module.exports = function (opts) {
   return {
     get oas2 () {
-      return getDefaultsForOAS2(getGenericDefaults(new StoplightKeyGenerator(() => "#/definitions", opts)));
+      return getDefaultsForOAS2(getGenericDefaults(new StoplightKeyGenerator(defaultOas2RootResolver, opts)));
     },
     get oas3 () {
-      return getDefaultsForOAS3(getGenericDefaults(new StoplightKeyGenerator(() => "#/components/schemas", opts)));
+      return getDefaultsForOAS3(getGenericDefaults(new StoplightKeyGenerator(defaultOas3RootResolver, opts)));
     },
     // eslint-disable-next-line camelcase
     get json_schema () {

--- a/lib/bundle/stoplight/generator.js
+++ b/lib/bundle/stoplight/generator.js
@@ -87,7 +87,7 @@ StoplightKeyGenerator.prototype.getExistingGeneratedKey = function (schema, id) 
   return KeyGenerator.prototype.getExistingGeneratedKey.call(this, schema, id);
 };
 
-StoplightKeyGenerator.prototype.generateKeyForUrl = function (schema, url) {
+StoplightKeyGenerator.prototype.generateKeyForUrl = function (schema, url, pathFromRoot) {
   let existingGeneratedKey = this.getExistingGeneratedKey(schema, url);
 
   if (existingGeneratedKey !== undefined) {
@@ -108,18 +108,18 @@ StoplightKeyGenerator.prototype.generateKeyForUrl = function (schema, url) {
       let key = this.getPrettifiedKeyForFilepath(filepath.replace(/_m[0-9]+$/, ""));
 
       if (query.mid && this.isKeyTaken(schema, key)) {
-        key = this.generateUniqueKey(schema, `${key}_m${query.mid}`);
+        key = this.generateUniqueKey(schema, `${key}_m${query.mid}`, pathFromRoot);
       }
       else {
-        key = this.generateUniqueKey(schema, key);
+        key = this.generateUniqueKey(schema, key, pathFromRoot);
       }
 
-      let generatedKey = this.registerNewGeneratedKey(schema, url, key);
+      let generatedKey = this.registerNewGeneratedKey(schema, url, key, pathFromRoot);
 
       // https://example.com/api/nodes.raw/?srn=org/proj/data-model-dictionary/reference/book.yaml and filepath from the same project
       // should be considered the same source, hence this extra registration call here
       // query.mid appended because mid does affect the way we treat the source
-      this.registerNewGeneratedKey(schema, filepath, key);
+      this.registerNewGeneratedKey(schema, filepath, key, pathFromRoot);
       return generatedKey;
     }
   }

--- a/lib/bundle/stoplight/generator.js
+++ b/lib/bundle/stoplight/generator.js
@@ -67,8 +67,8 @@ StoplightKeyGenerator.prototype.extractFilepathFromUrl = function (url) {
   return url;
 };
 
-StoplightKeyGenerator.prototype.generateKeyForFilepath = function (schema, filepath) {
-  return KeyGenerator.prototype.generateKeyForFilepath.call(this, schema, this.processPath(filepath));
+StoplightKeyGenerator.prototype.generateKeyForFilepath = function (schema, filepath, pathFromRoot) {
+  return KeyGenerator.prototype.generateKeyForFilepath.call(this, schema, this.processPath(filepath), pathFromRoot);
 };
 
 StoplightKeyGenerator.prototype.hasExistingGeneratedKey = function (schema, id) {
@@ -107,7 +107,7 @@ StoplightKeyGenerator.prototype.generateKeyForUrl = function (schema, url, pathF
 
       let key = this.getPrettifiedKeyForFilepath(filepath.replace(/_m[0-9]+$/, ""));
 
-      if (query.mid && this.isKeyTaken(schema, key)) {
+      if (query.mid && this.isKeyTaken(schema, key, pathFromRoot)) {
         key = this.generateUniqueKey(schema, `${key}_m${query.mid}`, pathFromRoot);
       }
       else {

--- a/lib/bundle/stoplight/legacy.js
+++ b/lib/bundle/stoplight/legacy.js
@@ -64,14 +64,14 @@ LegacyStoplightKeyGenerator.prototype.extractFilepathFromUrl = function (url) {
 module.exports = function (opts) {
   return {
     get oas2 () {
-      return getDefaultsForOAS2(getGenericDefaults(new LegacyStoplightKeyGenerator("#/definitions", opts)));
+      return getDefaultsForOAS2(getGenericDefaults(new LegacyStoplightKeyGenerator(() => "#/definitions", opts)));
     },
     get oas3 () {
-      return getDefaultsForOAS3(getGenericDefaults(new LegacyStoplightKeyGenerator("#/components/schemas", opts)));
+      return getDefaultsForOAS3(getGenericDefaults(new LegacyStoplightKeyGenerator(() => "#/components/schemas", opts)));
     },
     // eslint-disable-next-line camelcase
     get json_schema () {
-      return getDefaultsForOldJsonSchema(getGenericDefaults(new LegacyStoplightKeyGenerator("#/definitions", opts)));
+      return getDefaultsForOldJsonSchema(getGenericDefaults(new LegacyStoplightKeyGenerator(() => "#/definitions", opts)));
     },
   };
 };

--- a/lib/bundle/stoplight/legacy.js
+++ b/lib/bundle/stoplight/legacy.js
@@ -5,6 +5,8 @@ const StoplightKeyGenerator = require("./generator");
 const { parse, isHttp, isFileSystemPath } = require("../../util/url");
 const {
   getGenericDefaults,
+  defaultOas2RootResolver,
+  defaultOas3RootResolver,
   getDefaultsForOldJsonSchema,
   getDefaultsForOAS2,
   getDefaultsForOAS3,
@@ -64,10 +66,10 @@ LegacyStoplightKeyGenerator.prototype.extractFilepathFromUrl = function (url) {
 module.exports = function (opts) {
   return {
     get oas2 () {
-      return getDefaultsForOAS2(getGenericDefaults(new LegacyStoplightKeyGenerator(() => "#/definitions", opts)));
+      return getDefaultsForOAS2(getGenericDefaults(new LegacyStoplightKeyGenerator(defaultOas2RootResolver, opts)));
     },
     get oas3 () {
-      return getDefaultsForOAS3(getGenericDefaults(new LegacyStoplightKeyGenerator(() => "#/components/schemas", opts)));
+      return getDefaultsForOAS3(getGenericDefaults(new LegacyStoplightKeyGenerator(defaultOas3RootResolver, opts)));
     },
     // eslint-disable-next-line camelcase
     get json_schema () {

--- a/lib/bundle/util/key-generator.js
+++ b/lib/bundle/util/key-generator.js
@@ -38,7 +38,7 @@ KeyGenerator.appendSlash = function (str) {
 
 function KeyGenerator (root) {
   let rootFn = root;
-  if (typeof root === "string") {
+  if (!root || typeof root === "string") {
     rootFn = () => root;
   }
 

--- a/lib/bundle/util/key-generator.js
+++ b/lib/bundle/util/key-generator.js
@@ -82,8 +82,8 @@ Object.assign(KeyGenerator.prototype, {
     return state.takenKeys;
   },
 
-  isKeyTaken (schema, key) {
-    return this.getTakenKeys(schema).has(key);
+  isKeyTaken (schema, key, pathFromRoot) {
+    return this.getTakenKeys(schema, pathFromRoot).has(key);
   },
 
   getGeneratedKeys (schema) {
@@ -108,7 +108,7 @@ Object.assign(KeyGenerator.prototype, {
       let takenKeys = this.getTakenKeys(schema, pathFromRoot);
 
       takenKeys.add(key);
-      generatedKeys[id] = `${this.root()}/${key}`;
+      generatedKeys[id] = `${this.root(pathFromRoot)}/${key}`;
     }
 
     return generatedKeys[id];
@@ -122,11 +122,11 @@ Object.assign(KeyGenerator.prototype, {
     return suggestKey(this.getTakenKeys(schema, pathFromRoot), key);
   },
 
-  generateKeyForFilepath (schema, filepath) {
+  generateKeyForFilepath (schema, filepath, pathFromRoot) {
     if (!this.hasExistingGeneratedKey(schema, filepath)) {
-      let key = this.generateUniqueKey(schema, this.getPrettifiedKeyForFilepath(filepath));
+      let key = this.generateUniqueKey(schema, this.getPrettifiedKeyForFilepath(filepath), pathFromRoot);
 
-      this.registerNewGeneratedKey(schema, filepath, key);
+      this.registerNewGeneratedKey(schema, filepath, key, pathFromRoot);
     }
 
     return this.getExistingGeneratedKey(schema, filepath);
@@ -135,29 +135,29 @@ Object.assign(KeyGenerator.prototype, {
   generateKeyForUrl (schema, url, pathFromRoot) {
     if (!this.hasExistingGeneratedKey(schema, url)) {
       let { path } = parse(url, true);
-      let key = path === "/" ? null : this.generateUniqueKey(schema, this.getPrettifiedKeyForFilepath(path));
+      let key = path === "/" ? null : this.generateUniqueKey(schema, this.getPrettifiedKeyForFilepath(path), pathFromRoot);
 
-      this.registerNewGeneratedKey(schema, url, key);
+      this.registerNewGeneratedKey(schema, url, key, pathFromRoot);
     }
 
     return this.getExistingGeneratedKey(schema, url);
   },
 
-  generateKeyForPointer (schema, pointer) {
+  generateKeyForPointer (schema, pointer, pathFromRoot) {
     if (!this.hasExistingGeneratedKey(schema, pointer)) {
-      let fragment = KeyGenerator.appendSlash(this.root().slice(1));
+      let fragment = KeyGenerator.appendSlash(this.root(pathFromRoot).slice(1));
       let actualPath = pointer.split(fragment).slice(1);
-      let key = this.generateUniqueKey(schema, prettify(actualPath.join("/")));
+      let key = this.generateUniqueKey(schema, prettify(actualPath.join("/")), pathFromRoot);
 
-      this.registerNewGeneratedKey(schema, pointer, key);
+      this.registerNewGeneratedKey(schema, pointer, key, pathFromRoot);
     }
 
     return this.getExistingGeneratedKey(schema, pointer);
   },
 
-  isInRoot (pointer) {
+  isInRoot (pointer, pathFromRoot) {
     let parsedPointer = safePointerToPath(pointer);
-    let parsedRoot = safePointerToPath(this.root());
+    let parsedRoot = safePointerToPath(this.root(pathFromRoot));
 
     if (parsedRoot.length >= parsedPointer.length) {
       return false;
@@ -172,14 +172,14 @@ Object.assign(KeyGenerator.prototype, {
     return true;
   },
 
-  isUnderDirectRoot (pointer) {
+  isUnderDirectRoot (pointer, pathFromRoot) {
     let parsedPointer = safePointerToPath(pointer);
-    let parsedRoot = safePointerToPath(this.root());
+    let parsedRoot = safePointerToPath(this.root(pathFromRoot));
 
     if (parsedPointer.length !== parsedRoot.length + 1) {
       return false;
     }
 
-    return this.isInRoot(pointer);
+    return this.isInRoot(pointer, pathFromRoot);
   }
 });

--- a/lib/bundle/util/key-generator.js
+++ b/lib/bundle/util/key-generator.js
@@ -38,7 +38,6 @@ KeyGenerator.appendSlash = function (str) {
 
 function KeyGenerator (root) {
   this.root = root;
-  this._parsedRoot = safePointerToPath(root);
   this._seenSchemas = new WeakMap();
 }
 
@@ -67,11 +66,11 @@ Object.assign(KeyGenerator.prototype, {
     };
   },
 
-  getTakenKeys (schema) {
+  getTakenKeys (schema, pathFromRoot) {
     let { state, reused } = this._initializeOrReuseStateForSchema(schema);
 
     if (!reused) {
-      let schemaRoot = get(schema, this.root);
+      let schemaRoot = get(schema, this.root(pathFromRoot));
 
       if (typeof schemaRoot === "object" && schemaRoot !== null) {
         for (let key of Object.keys(schemaRoot)) {
@@ -99,17 +98,17 @@ Object.assign(KeyGenerator.prototype, {
     return id in this.getGeneratedKeys(schema);
   },
 
-  registerNewGeneratedKey (schema, id, key) {
+  registerNewGeneratedKey (schema, id, key, pathFromRoot) {
     let generatedKeys = this.getGeneratedKeys(schema);
 
     if (key === null) {
       generatedKeys[id] = key;
     }
     else {
-      let takenKeys = this.getTakenKeys(schema);
+      let takenKeys = this.getTakenKeys(schema, pathFromRoot);
 
       takenKeys.add(key);
-      generatedKeys[id] = `${this.root}/${key}`;
+      generatedKeys[id] = `${this.root()}/${key}`;
     }
 
     return generatedKeys[id];
@@ -119,8 +118,8 @@ Object.assign(KeyGenerator.prototype, {
     return prettify(basename(filepath, extname(filepath)));
   },
 
-  generateUniqueKey (schema, key) {
-    return suggestKey(this.getTakenKeys(schema), key);
+  generateUniqueKey (schema, key, pathFromRoot) {
+    return suggestKey(this.getTakenKeys(schema, pathFromRoot), key);
   },
 
   generateKeyForFilepath (schema, filepath) {
@@ -133,7 +132,7 @@ Object.assign(KeyGenerator.prototype, {
     return this.getExistingGeneratedKey(schema, filepath);
   },
 
-  generateKeyForUrl (schema, url) {
+  generateKeyForUrl (schema, url, pathFromRoot) {
     if (!this.hasExistingGeneratedKey(schema, url)) {
       let { path } = parse(url, true);
       let key = path === "/" ? null : this.generateUniqueKey(schema, this.getPrettifiedKeyForFilepath(path));
@@ -146,7 +145,7 @@ Object.assign(KeyGenerator.prototype, {
 
   generateKeyForPointer (schema, pointer) {
     if (!this.hasExistingGeneratedKey(schema, pointer)) {
-      let fragment = KeyGenerator.appendSlash(this.root.slice(1));
+      let fragment = KeyGenerator.appendSlash(this.root().slice(1));
       let actualPath = pointer.split(fragment).slice(1);
       let key = this.generateUniqueKey(schema, prettify(actualPath.join("/")));
 
@@ -158,13 +157,14 @@ Object.assign(KeyGenerator.prototype, {
 
   isInRoot (pointer) {
     let parsedPointer = safePointerToPath(pointer);
+    let parsedRoot = safePointerToPath(this.root());
 
-    if (this._parsedRoot.length >= parsedPointer.length) {
+    if (parsedRoot.length >= parsedPointer.length) {
       return false;
     }
 
-    for (let i = this._parsedRoot.length - 1; i >= 0; i--) {
-      if (parsedPointer[parsedPointer.length - (this._parsedRoot.length - i) - 1] !== this._parsedRoot[i]) {
+    for (let i = parsedRoot.length - 1; i >= 0; i--) {
+      if (parsedPointer[parsedPointer.length - (parsedRoot.length - i) - 1] !== parsedRoot[i]) {
         return false;
       }
     }
@@ -174,8 +174,9 @@ Object.assign(KeyGenerator.prototype, {
 
   isUnderDirectRoot (pointer) {
     let parsedPointer = safePointerToPath(pointer);
+    let parsedRoot = safePointerToPath(this.root());
 
-    if (parsedPointer.length !== this._parsedRoot.length + 1) {
+    if (parsedPointer.length !== parsedRoot.length + 1) {
       return false;
     }
 

--- a/lib/bundle/util/key-generator.js
+++ b/lib/bundle/util/key-generator.js
@@ -172,14 +172,14 @@ Object.assign(KeyGenerator.prototype, {
     return true;
   },
 
-  isUnderDirectRoot (pointer, pathFromRoot) {
+  isUnderDirectRoot (pointer) {
     let parsedPointer = safePointerToPath(pointer);
-    let parsedRoot = safePointerToPath(this.root(pathFromRoot));
+    let parsedRoot = safePointerToPath(this.root(pointer));
 
     if (parsedPointer.length !== parsedRoot.length + 1) {
       return false;
     }
 
-    return this.isInRoot(pointer, pathFromRoot);
+    return this.isInRoot(pointer, pointer);
   }
 });

--- a/lib/bundle/util/key-generator.js
+++ b/lib/bundle/util/key-generator.js
@@ -37,7 +37,12 @@ KeyGenerator.appendSlash = function (str) {
 };
 
 function KeyGenerator (root) {
-  this.root = root;
+  let rootFn = root;
+  if (typeof root === "string") {
+    rootFn = () => root;
+  }
+
+  this.root = rootFn;
   this._seenSchemas = new WeakMap();
 }
 

--- a/lib/bundle/util/key-generator.js
+++ b/lib/bundle/util/key-generator.js
@@ -37,12 +37,7 @@ KeyGenerator.appendSlash = function (str) {
 };
 
 function KeyGenerator (root) {
-  let rootFn = root;
-  if (!root || typeof root === "string") {
-    rootFn = () => root;
-  }
-
-  this.root = rootFn;
+  this.root = typeof root === "function" ? root : () => root;
   this._seenSchemas = new WeakMap();
 }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -248,7 +248,7 @@ declare namespace $RefParser {
       /**
        * The default root to optimize for.
        */
-      defaultRoot?: string;
+      defaultRoot?: string | ((pathToRoot: string) => string | null);
     };
   }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -92,7 +92,8 @@ $RefParserOptions.defaults = {
     /**
      * The default root to optimize for.
      *
-     * @type {string}
+     * @typedef {function((string)): (string|null)} RootFunction
+     * @type {string|RootFunction}
      */
     defaultRoot: "#/definitions"
   }

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/headers/X-RateLimit-Remaining.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/headers/X-RateLimit-Remaining.json
@@ -1,0 +1,7 @@
+{
+  "description": "Request limit per hour",
+  "schema": {
+    "type": "integer"
+  },
+  "example": 100
+}

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-bundled.js
@@ -41,7 +41,10 @@ module.exports = {
             schema: {
               $ref: "#/definitions/Flight"
             }
-          }
+          },
+          400: {
+            $ref: "#/responses/ExampleResponse"
+          },
         }
       }
     }
@@ -196,6 +199,22 @@ module.exports = {
       name: "id",
       required: true,
       type: "number",
+    },
+  },
+  responses: {
+    ExampleResponse: {
+      content: {
+        "application/json": {
+          schema: {
+            properties: {
+              id: {
+                type: "string",
+              },
+            },
+          },
+        },
+      },
+      description: "Example response",
     },
   },
 };

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-bundled.js
@@ -10,10 +10,7 @@ module.exports = {
     "/flight/{id}": {
       parameters: [
         {
-          in: "path",
-          name: "id",
-          required: true,
-          type: "number"
+          $ref: "#/parameters/Id"
         }
       ],
       get: {
@@ -192,5 +189,13 @@ module.exports = {
       minLength: 2,
       maxLength: 50
     },
-  }
+  },
+  parameters: {
+    Id: {
+      in: "path",
+      name: "id",
+      required: true,
+      type: "number",
+    },
+  },
 };

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2.json
@@ -40,6 +40,9 @@
             "schema": {
               "$ref": "#/definitions/Flight"
             }
+          },
+          "400": {
+            "$ref": "./responses/exampleResponse.json"
           }
         }
       }

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.bundled.js
@@ -52,6 +52,11 @@ module.exports = {
                   $ref: "#/components/schemas/Flight"
                 }
               }
+            },
+            headers: {
+              "X-RateLimit-Remaining": {
+                $ref: "#/components/headers/X-RateLimit-Remaining",
+              },
             }
           }
         }
@@ -85,6 +90,15 @@ module.exports = {
         },
         description: "example request body",
         required: true,
+      },
+    },
+    headers: {
+      "X-RateLimit-Remaining": {
+        description: "Request limit per hour",
+        example: 100,
+        schema: {
+          type: "integer",
+        },
       },
     },
     schemas: {

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.bundled.js
@@ -14,11 +14,8 @@ module.exports = {
     "/flight/{id}": {
       parameters: [
         {
-          in: "path",
-          name: "id",
-          required: true,
-          type: "number"
-        },
+          $ref: "#/components/parameters/Id"
+        }
       ],
       get: {
         operationId: "get-flights",
@@ -62,6 +59,14 @@ module.exports = {
     }
   },
   components: {
+    parameters: {
+      Id: {
+        in: "path",
+        name: "id",
+        required: true,
+        type: "number",
+      },
+    },
     schemas: {
       Airport: {
         definitions: {},

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.bundled.js
@@ -103,39 +103,41 @@ module.exports = {
     },
     schemas: {
       Airport: {
-        definitions: {},
+        definitions: {
+          Name: {
+            example: "JFK",
+            maxLength: 50,
+            minLength: 2,
+            type: "string"
+          }
+        },
         properties: {
           id: {
             type: "number"
           },
           name: {
-            $ref: "#/components/schemas/Airport_Name"
+            $ref: "#/components/schemas/Airport/definitions/Name"
           }
         },
         title: "Airport",
         type: "object"
       },
       Airport_m123: {
-        definitions: {},
+        definitions: {
+          Name: {
+            example: "JFK",
+            maxLength: 50,
+            minLength: 2,
+            type: "string"
+          }
+        },
         properties: {
           name: {
-            $ref: "#/components/schemas/Airport_m123_Name"
+            $ref: "#/components/schemas/Airport_m123/definitions/Name"
           }
         },
         title: "Airport",
         type: "object"
-      },
-      Airport_Name: {
-        example: "JFK",
-        maxLength: 50,
-        minLength: 2,
-        type: "string"
-      },
-      Airport_m123_Name: {
-        example: "JFK",
-        maxLength: 50,
-        minLength: 2,
-        type: "string"
       },
       Flight: {
         title: "Flight",
@@ -169,30 +171,38 @@ module.exports = {
       },
 
       User: {
-        definitions: {},
+        definitions: {
+          Name: {
+            type: "string",
+            minLength: 2,
+            maxLength: 20
+          }
+        },
         title: "User",
         type: "object",
         properties: {
           firstName: {
-            $ref: "#/components/schemas/User_Name"
+            $ref: "#/components/schemas/User/definitions/Name"
           },
           lastName: {
-            $ref: "#/components/schemas/User_Name"
+            $ref: "#/components/schemas/User/definitions/Name"
           }
         }
       },
-      User_Name: {
-        type: "string",
-        minLength: 2,
-        maxLength: 20
-      },
       'Airplane.v1': {
-        definitions: {},
+        definitions: {
+          Name: {
+            example: "747",
+            maxLength: 100,
+            minLength: 1,
+            type: "string",
+          },
+        },
         title: "Airplane",
         type: "object",
         properties: {
           name: {
-            $ref: "#/components/schemas/Airplane.v1_Name"
+            $ref: "#/components/schemas/Airplane.v1/definitions/Name"
           },
           repairman: {
             $ref: "#/components/schemas/User"
@@ -202,49 +212,45 @@ module.exports = {
           }
         }
       },
-      'Airplane.v1_Name': {
-        type: "string",
-        minLength: 1,
-        maxLength: 100,
-        example: "747"
-      },
       Manufacturer: {
-        definitions: {},
+        definitions: {
+          Name: {
+            maxLength: 20,
+            minLength: 2,
+            type: "string",
+          }
+        },
         title: "Manufacturer",
         type: "object",
         properties: {
           name: {
-            $ref: "#/components/schemas/Manufacturer_Name"
+            $ref: "#/components/schemas/Manufacturer/definitions/Name"
           },
           owner: {
             $ref: "#/components/schemas/User_2"
           }
         }
       },
-      Manufacturer_Name: {
-        type: "string",
-        minLength: 2,
-        maxLength: 20
-      },
       User_2: {
-        definitions: {},
+        definitions: {
+          Name: {
+            type: "string",
+            minLength: 2,
+            maxLength: 50
+          }
+        },
         title: "Alt User",
         description: "Allows for a longer name than regular user",
         type: "object",
         properties: {
           firstName: {
-            $ref: "#/components/schemas/User_2_Name"
+            $ref: "#/components/schemas/User_2/definitions/Name"
           },
           lastName: {
-            $ref: "#/components/schemas/User_2_Name"
+            $ref: "#/components/schemas/User_2/definitions/Name"
           }
         }
-      },
-      User_2_Name: {
-        type: "string",
-        minLength: 2,
-        maxLength: 50
-      },
+      }
     }
   }
 };

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.bundled.js
@@ -55,7 +55,13 @@ module.exports = {
             }
           }
         }
-      }
+      },
+      patch: {
+        operationId: "patch-flight-id",
+        requestBody: {
+          $ref: "#/components/requestBodies/ExampleRequestBody",
+        },
+      },
     }
   },
   components: {
@@ -65,6 +71,20 @@ module.exports = {
         name: "id",
         required: true,
         type: "number",
+      },
+    },
+    requestBodies: {
+      ExampleRequestBody: {
+        content: {
+          "application/json": {
+            schema: {
+              name: "title",
+              type: "string",
+            },
+          },
+        },
+        description: "example request body",
+        required: true,
       },
     },
     schemas: {

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.json
@@ -34,7 +34,7 @@
       "patch": {
         "operationId": "patch-flight-id",
         "requestBody": {
-            "$ref": "./requestBodies/exampleRequestBody.json"
+          "$ref": "./requestBodies/exampleRequestBody.json"
         }
       },
       "post": {
@@ -56,6 +56,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/Flight"
                 }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Remaining": {
+                "$ref": "./headers/X-RateLimit-Remaining.json"
               }
             }
           }

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-3.json
@@ -31,6 +31,12 @@
           }
         }
       },
+      "patch": {
+        "operationId": "patch-flight-id",
+        "requestBody": {
+            "$ref": "./requestBodies/exampleRequestBody.json"
+        }
+      },
       "post": {
         "operationId": "post-flight-id",
         "requestBody": {

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/requestBodies/exampleRequestBody.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/requestBodies/exampleRequestBody.json
@@ -1,0 +1,12 @@
+{
+  "description": "example request body",
+  "required": true,
+  "content": {
+    "application/json": {
+      "schema": {
+        "type": "string",
+        "name": "title"
+      }
+    }
+  }
+}

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/responses/exampleResponse.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/responses/exampleResponse.json
@@ -1,0 +1,14 @@
+{
+  "description": "Example response",
+  "content": {
+    "application/json": {
+      "schema": {
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/specs/custom-bundling-roots/custom-bundling-roots.spec.js
+++ b/test/specs/custom-bundling-roots/custom-bundling-roots.spec.js
@@ -607,16 +607,21 @@ describe("Custom bundling roots", () => {
                   }
                 },
                 400: {
-                  title: "Pets"
+                  $ref: "#/components/responses/Pets"
                 },
                 500: {
-                  $ref: "#/paths/~1pets/get/responses/400"
+                  $ref: "#/components/responses/Pets"
                 }
               }
             }
           },
         },
         components: {
+          responses: {
+            Pets: {
+              title: "Pets"
+            }
+          },
           parameters: {
             Book: {
               name: "Book"

--- a/test/specs/custom-bundling-roots/custom-bundling-roots.spec.js
+++ b/test/specs/custom-bundling-roots/custom-bundling-roots.spec.js
@@ -585,10 +585,10 @@ describe("Custom bundling roots", () => {
             get: {
               parameters: [
                 {
-                  name: "Book"
+                  $ref: "#/components/parameters/Book"
                 },
                 {
-                  $ref: "#/paths/~1pets/get/parameters/0"
+                  $ref: "#/components/parameters/Book"
                 }
               ],
               responses: {
@@ -617,6 +617,11 @@ describe("Custom bundling roots", () => {
           },
         },
         components: {
+          parameters: {
+            Book: {
+              name: "Book"
+            }
+          },
           schemas: {
             Address: {
               title: "Address"


### PR DESCRIPTION
For https://github.com/stoplightio/platform-internal/issues/5263

Biggest change is refactoring `KeyGenerator` root param into function that accepts `pathFromRoot. Based on that we can determine if the refs should be placed in `#/definitions`, `#/parameters` or similar