### PR TITLE
shared component bundle issue

### DIFF
--- a/test/specs/custom-bundling-roots-legacy-stoplight/custom-bundling-roots-legacy-stoplight.spec.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/custom-bundling-roots-legacy-stoplight.spec.js
@@ -36,6 +36,17 @@ describe("Stoplight-specific (legacy) defaults", () => {
       expect(schema).to.deep.equal(require("./reference/openapi-2-bundled.js"));
     });
 
+    it("should no dereference schema", async () => {
+      let parser = new $RefParser();
+
+      const schema = await parser.bundle(path.rel("specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/openapi.json"), {
+        bundle: defaults.oas2,
+      });
+
+      expect(schema).to.equal(parser.schema);
+      expect(schema).to.deep.equal(require("./reference/openapi-2-todos-bundled.js"));
+    });
+
     it("should allow to customize bundling roots for OAS3", async () => {
       let parser = new $RefParser();
 

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-todos-bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-todos-bundled.js
@@ -76,7 +76,7 @@ module.exports = {
             $ref: "#/responses/420",
           },
           500: {
-            $ref: "#/paths/~1todos/get/responses/500",
+            $ref: "#/responses/Shared_500",
           },
         },
       },
@@ -115,13 +115,13 @@ module.exports = {
             },
           },
           401: {
-            $ref: "#/paths/~1todos/post/responses/401",
+            $ref: "#/responses/Shared_401",
           },
           404: {
-            $ref: "#/paths/~1todos~1%7BtodoId%7D/get/responses/404",
+            $ref: "#/responses/Shared_404",
           },
           500: {
-            $ref: "#/paths/~1todos/get/responses/500",
+            $ref: "#/responses/Shared_500",
           },
         },
         security: [
@@ -139,13 +139,13 @@ module.exports = {
             description: "",
           },
           401: {
-            $ref: "#/paths/~1todos/post/responses/401",
+            $ref: "#/responses/Shared_401",
           },
           404: {
-            $ref: "#/paths/~1todos~1%7BtodoId%7D/get/responses/404",
+            $ref: "#/responses/Shared_404",
           },
           500: {
-            $ref: "#/paths/~1todos/get/responses/500",
+            $ref: "#/responses/Shared_500",
           },
         },
         security: [
@@ -191,19 +191,10 @@ module.exports = {
             },
           },
           401: {
-            description: "Our shared 401 response.",
-            schema: {
-              $ref: "#/definitions/Error",
-            },
-            examples: {
-              "application/json": {
-                code: "401",
-                message: "Not Authorized",
-              },
-            },
+            $ref: "$/responses/Shared_401"
           },
           500: {
-            $ref: "#/paths/~1todos/get/responses/500",
+            $ref: "#/responses/Shared_500",
           },
         },
         security: [
@@ -277,6 +268,42 @@ module.exports = {
         $ref: "#/definitions/User",
       },
     },
+    Shared_401: {
+      description: "Our shared 401 response.",
+      schema: {
+        $ref: "#/definitions/Error",
+      },
+      examples: {
+        "application/json": {
+          code: "401",
+          message: "Not Authorized",
+        },
+      },
+    },
+    Shared_404: {
+      description: "Our shared 404 response.",
+      schema: {
+        $ref: "#/definitions/Error",
+      },
+      examples: {
+        "application/json": {
+          code: "404",
+          message: "Not Found",
+        },
+      },
+    },
+    Shared_500: {
+      description: "Our shared 500 response.",
+      schema: {
+        $ref: "#/definitions/Error",
+      },
+      examples: {
+        "application/json": {
+          code: "500",
+          message: "Server Error",
+        },
+      },
+    }
   },
   definitions: {
     embedded: {

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-todos-bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-todos-bundled.js
@@ -1,0 +1,393 @@
+/* eslint-disable */
+module.exports = {
+  swagger: "2.0",
+  info: {
+    title: "To-dos",
+    version: "1.0",
+    description:
+      "This OpenAPI v2 (Swagger) file represents a real API that lives at http://todos.stoplight.io.\n\nIt exposes functionality to manage to-do lists.",
+    contact: {
+      name: "Stoplight",
+      url: "https://stoplight.io",
+    },
+    license: {
+      name: "MIT",
+    },
+  },
+  host: "todos.stoplight.io",
+  schemes: ["https", "http"],
+  consumes: ["application/json"],
+  produces: ["application/json"],
+  securityDefinitions: {
+    apikey: {
+      name: "apikey",
+      type: "apiKey",
+      in: "query",
+      description:
+        "Use `?apikey=123` to authenticate requests. It's super secure.",
+    },
+  },
+  tags: [
+    {
+      name: "Todos",
+    },
+  ],
+  paths: {
+    "/todos/{todoId}": {
+      parameters: [
+        {
+          $ref: "#/parameters/todoId",
+        },
+      ],
+      get: {
+        operationId: "GET_todo",
+        summary: "Get Todo",
+        tags: ["Todos"],
+        responses: {
+          200: {
+            description: "",
+            schema: {
+              $ref: "#/definitions/Todo-full",
+            },
+            examples: {
+              "application/json": {
+                id: 1,
+                name: "get food",
+                completed: false,
+                completed_at: "1955-04-23T13:22:52.685Z",
+                created_at: "1994-11-05T03:26:51.471Z",
+                updated_at: "1989-07-29T11:30:06.701Z",
+              },
+            },
+          },
+          404: {
+            description: "Our shared 404 response.",
+            schema: {
+              $ref: "#/definitions/Error",
+            },
+            examples: {
+              "application/json": {
+                code: "404",
+                message: "Not Found",
+              },
+            },
+          },
+          420: {
+            $ref: "#/responses/420",
+          },
+          500: {
+            $ref: "#/paths/~1todos/get/responses/500",
+          },
+        },
+      },
+      put: {
+        operationId: "PUT_todos",
+        summary: "Update Todo",
+        tags: ["Todos"],
+        parameters: [
+          {
+            name: "body",
+            in: "body",
+            schema: {
+              $ref: "#/definitions/Todo-partial",
+              example: {
+                name: "my todo's new name",
+                completed: false,
+              },
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: "",
+            schema: {
+              $ref: "#/definitions/Todo-full",
+            },
+            examples: {
+              "application/json": {
+                id: 9000,
+                name: "It's Over 9000!!!",
+                completed: true,
+                completed_at: null,
+                created_at: "2014-08-28T14:14:28.494Z",
+                updated_at: "2015-08-28T14:14:28.494Z",
+              },
+            },
+          },
+          401: {
+            $ref: "#/paths/~1todos/post/responses/401",
+          },
+          404: {
+            $ref: "#/paths/~1todos~1%7BtodoId%7D/get/responses/404",
+          },
+          500: {
+            $ref: "#/paths/~1todos/get/responses/500",
+          },
+        },
+        security: [
+          {
+            apikey: [],
+          },
+        ],
+      },
+      delete: {
+        operationId: "DELETE_todo",
+        summary: "Delete Todo",
+        tags: ["Todos"],
+        responses: {
+          204: {
+            description: "",
+          },
+          401: {
+            $ref: "#/paths/~1todos/post/responses/401",
+          },
+          404: {
+            $ref: "#/paths/~1todos~1%7BtodoId%7D/get/responses/404",
+          },
+          500: {
+            $ref: "#/paths/~1todos/get/responses/500",
+          },
+        },
+        security: [
+          {
+            apikey: [],
+          },
+        ],
+      },
+    },
+    "/todos": {
+      post: {
+        operationId: "POST_todos",
+        summary: "Create Todo",
+        tags: ["Todos"],
+        parameters: [
+          {
+            name: "body",
+            in: "body",
+            schema: {
+              $ref: "#/definitions/Todo-partial",
+              example: {
+                name: "my todo's name",
+                completed: false,
+              },
+            },
+          },
+        ],
+        responses: {
+          201: {
+            description: "",
+            schema: {
+              $ref: "#/definitions/Todo-full",
+            },
+            examples: {
+              "application/json": {
+                id: 9000,
+                name: "It's Over 9000!!!",
+                completed: null,
+                completed_at: null,
+                created_at: "2014-08-28T14:14:28.494Z",
+                updated_at: "2014-08-28T14:14:28.494Z",
+              },
+            },
+          },
+          401: {
+            description: "Our shared 401 response.",
+            schema: {
+              $ref: "#/definitions/Error",
+            },
+            examples: {
+              "application/json": {
+                code: "401",
+                message: "Not Authorized",
+              },
+            },
+          },
+          500: {
+            $ref: "#/paths/~1todos/get/responses/500",
+          },
+        },
+        security: [
+          {
+            apikey: [],
+          },
+        ],
+        description: "This creates a Todo object.\n\nTesting `inline code`.",
+      },
+      get: {
+        operationId: "GET_todos",
+        summary: "List Todos",
+        tags: ["Todos"],
+        responses: {
+          200: {
+            description: "",
+            schema: {
+              type: "array",
+              items: {
+                $ref: "#/definitions/Todo-full",
+              },
+            },
+            examples: {
+              "application/json": [
+                {
+                  id: 1,
+                  name: "design the thingz",
+                  completed: true,
+                },
+                {
+                  id: 2,
+                  name: "mock the thingz",
+                  completed: true,
+                },
+                {
+                  id: 3,
+                  name: "code the thingz",
+                  completed: false,
+                },
+              ],
+            },
+          },
+          500: {
+            description: "Our shared 500 response.",
+            schema: {
+              $ref: "#/definitions/Error",
+            },
+            examples: {
+              "application/json": {
+                code: "500",
+                message: "Server Error",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  parameters: {
+    todoId: {
+      name: "todoId",
+      in: "path",
+      required: true,
+      type: "string",
+    },
+  },
+  responses: {
+    420: {
+      description: "Stay calm and carry on. Should render the user model",
+      schema: {
+        $ref: "#/definitions/User",
+      },
+    },
+  },
+  definitions: {
+    embedded: {
+      title: "Embedded Model",
+      properties: {
+        id: {
+          type: "string",
+        },
+        todo: {
+          $ref: "#/definitions/Todo-full",
+        },
+      },
+    },
+    Error: {
+      title: "Error",
+      type: "object",
+      description: "A standard error object.",
+      "x-tags": ["Common"],
+      properties: {
+        code: {
+          type: "string",
+          description: "A code.",
+        },
+        message: {
+          type: "string",
+        },
+      },
+      required: ["code"],
+    },
+    Card: {
+      title: "card",
+      type: "object",
+      description: "",
+      properties: {
+        id: {
+          type: "string",
+        },
+        number: {
+          type: "string",
+        },
+      },
+      required: ["number"],
+    },
+    "Todo-full": {
+      title: "Todo Full",
+      allOf: [
+        {
+          $ref: "#/definitions/Todo-partial",
+        },
+        {
+          type: "object",
+          properties: {
+            id: {
+              type: "integer",
+              minimum: 0,
+              maximum: 1000000,
+            },
+            completed_at: {
+              type: ["string", "null"],
+              format: "date-time",
+            },
+            created_at: {
+              type: "string",
+              format: "date-time",
+            },
+            updated_at: {
+              type: "string",
+              format: "date-time",
+            },
+            user: {
+              $ref: "#/definitions/User",
+            },
+          },
+          required: ["id", "user"],
+        },
+      ],
+      "x-tags": ["Todos"],
+    },
+    "Todo-partial": {
+      title: "Todo Partial",
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+        },
+        completed: {
+          type: ["boolean", "null"],
+        },
+      },
+      required: ["name", "completed"],
+      "x-tags": ["Todos"],
+    },
+    User: {
+      title: "User",
+      type: "object",
+      "x-tags": ["Todos"],
+      properties: {
+        name: {
+          type: "string",
+          description: "The user's full name.",
+        },
+        age: {
+          type: "number",
+          minimum: 0,
+          maximum: 150,
+        },
+        card: {
+          $ref: "#/definitions/Card",
+        },
+      },
+      required: ["name", "age"],
+    },
+  },
+};

--- a/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-todos-bundled.js
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/reference/openapi-2-todos-bundled.js
@@ -61,16 +61,7 @@ module.exports = {
             },
           },
           404: {
-            description: "Our shared 404 response.",
-            schema: {
-              $ref: "#/definitions/Error",
-            },
-            examples: {
-              "application/json": {
-                code: "404",
-                message: "Not Found",
-              },
-            },
+            $ref: "#/responses/Shared_404",
           },
           420: {
             $ref: "#/responses/420",
@@ -191,7 +182,7 @@ module.exports = {
             },
           },
           401: {
-            $ref: "$/responses/Shared_401"
+            $ref: "#/responses/Shared_401"
           },
           500: {
             $ref: "#/responses/Shared_500",
@@ -238,16 +229,7 @@ module.exports = {
             },
           },
           500: {
-            description: "Our shared 500 response.",
-            schema: {
-              $ref: "#/definitions/Error",
-            },
-            examples: {
-              "application/json": {
-                code: "500",
-                message: "Server Error",
-              },
-            },
+            $ref: "#/responses/Shared_500"
           },
         },
       },

--- a/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/common/models/error.yaml
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/common/models/error.yaml
@@ -1,0 +1,13 @@
+title: Error
+type: object
+description: A standard error object.
+x-tags:
+  - Common
+properties:
+  code:
+    type: string
+    description: A code.
+  message:
+    type: string
+required:
+  - code

--- a/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/common/shared.yaml
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/common/shared.yaml
@@ -1,0 +1,46 @@
+parameters:
+  skip:
+    in: query
+    type: string
+    name: skip
+  rate-limit:
+    name: Rate-Limit
+    in: header
+    type: string
+  limit:
+    name: limit
+    in: query
+    type: string
+responses:
+  "401":
+    description: Our shared 401 response.
+    schema:
+      "$ref": "./models/error.yaml"
+    examples:
+      application/json:
+        code: "401"
+        message: Not Authorized
+  "403":
+    description: Our shared 403 response.
+    schema:
+      "$ref": "./models/error.yaml"
+    examples:
+      application/json:
+        code: "403"
+        message: Forbbiden
+  "404":
+    description: Our shared 404 response.
+    schema:
+      "$ref": "./models/error.yaml"
+    examples:
+      application/json:
+        code: "404"
+        message: Not Found
+  "500":
+    description: Our shared 500 response.
+    schema:
+      "$ref": "./models/error.yaml"
+    examples:
+      application/json:
+        code: "500"
+        message: Server Error

--- a/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/folder with spaces/card.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/folder with spaces/card.json
@@ -1,0 +1,16 @@
+{
+  "title": "card",
+  "type": "object",
+  "description": "",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "number": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "number"
+  ]
+}

--- a/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/models/todo-full.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/models/todo-full.json
@@ -1,0 +1,35 @@
+{
+  "title": "Todo Full",
+  "allOf": [
+    {
+      "$ref": "./todo-partial.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000
+        },
+        "completed_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "user": {
+          "$ref": "./user.json"
+        }
+      },
+      "required": ["id", "user"]
+    }
+  ],
+  "x-tags": ["Todos"]
+}

--- a/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/models/todo-partial.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/models/todo-partial.json
@@ -1,0 +1,22 @@
+{
+  "title": "Todo Partial",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "completed": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "completed"
+  ],
+  "x-tags": [
+    "Todos"
+  ]
+}

--- a/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/models/user.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/models/user.json
@@ -1,0 +1,25 @@
+{
+  "title": "User",
+  "type": "object",
+  "x-tags": [
+    "Todos"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The user's full name."
+    },
+    "age": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 150
+    },
+    "card": {
+      "$ref": "../folder with spaces/card.json"
+    }
+  },
+  "required": [
+    "name",
+    "age"
+  ]
+}

--- a/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/openapi.json
+++ b/test/specs/custom-bundling-roots-legacy-stoplight/todos-reference/todos/openapi.json
@@ -1,0 +1,264 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "To-dos",
+    "version": "1.0",
+    "description": "This OpenAPI v2 (Swagger) file represents a real API that lives at http://todos.stoplight.io.\n\nIt exposes functionality to manage to-do lists.",
+    "contact": {
+      "name": "Stoplight",
+      "url": "https://stoplight.io"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "todos.stoplight.io",
+  "schemes": ["https", "http"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "securityDefinitions": {
+    "apikey": {
+      "name": "apikey",
+      "type": "apiKey",
+      "in": "query",
+      "description": "Use `?apikey=123` to authenticate requests. It's super secure."
+    }
+  },
+  "tags": [
+    {
+      "name": "Todos"
+    }
+  ],
+  "paths": {
+    "/todos/{todoId}": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/todoId"
+        }
+      ],
+      "get": {
+        "operationId": "GET_todo",
+        "summary": "Get Todo",
+        "tags": ["Todos"],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "./models/todo-full.json"
+            },
+            "examples": {
+              "application/json": {
+                "id": 1,
+                "name": "get food",
+                "completed": false,
+                "completed_at": "1955-04-23T13:22:52.685Z",
+                "created_at": "1994-11-05T03:26:51.471Z",
+                "updated_at": "1989-07-29T11:30:06.701Z"
+              }
+            }
+          },
+          "404": {
+            "$ref": "../common/shared.yaml#/responses/404"
+          },
+          "420": {
+            "$ref": "#/responses/420"
+          },
+          "500": {
+            "$ref": "../common/shared.yaml#/responses/500"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PUT_todos",
+        "summary": "Update Todo",
+        "tags": ["Todos"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "./models/todo-partial.json",
+              "example": {
+                "name": "my todo's new name",
+                "completed": false
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "./models/todo-full.json"
+            },
+            "examples": {
+              "application/json": {
+                "id": 9000,
+                "name": "It's Over 9000!!!",
+                "completed": true,
+                "completed_at": null,
+                "created_at": "2014-08-28T14:14:28.494Z",
+                "updated_at": "2015-08-28T14:14:28.494Z"
+              }
+            }
+          },
+          "401": {
+            "$ref": "../common/shared.yaml#/responses/401"
+          },
+          "404": {
+            "$ref": "../common/shared.yaml#/responses/404"
+          },
+          "500": {
+            "$ref": "../common/shared.yaml#/responses/500"
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DELETE_todo",
+        "summary": "Delete Todo",
+        "tags": ["Todos"],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "$ref": "../common/shared.yaml#/responses/401"
+          },
+          "404": {
+            "$ref": "../common/shared.yaml#/responses/404"
+          },
+          "500": {
+            "$ref": "../common/shared.yaml#/responses/500"
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ]
+      }
+    },
+    "/todos": {
+      "post": {
+        "operationId": "POST_todos",
+        "summary": "Create Todo",
+        "tags": ["Todos"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "./models/todo-partial.json",
+              "example": {
+                "name": "my todo's name",
+                "completed": false
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "./models/todo-full.json"
+            },
+            "examples": {
+              "application/json": {
+                "id": 9000,
+                "name": "It's Over 9000!!!",
+                "completed": null,
+                "completed_at": null,
+                "created_at": "2014-08-28T14:14:28.494Z",
+                "updated_at": "2014-08-28T14:14:28.494Z"
+              }
+            }
+          },
+          "401": {
+            "$ref": "../common/shared.yaml#/responses/401"
+          },
+          "500": {
+            "$ref": "../common/shared.yaml#/responses/500"
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "description": "This creates a Todo object.\n\nTesting `inline code`."
+      },
+      "get": {
+        "operationId": "GET_todos",
+        "summary": "List Todos",
+        "tags": ["Todos"],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "./models/todo-full.json"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": 1,
+                  "name": "design the thingz",
+                  "completed": true
+                },
+                {
+                  "id": 2,
+                  "name": "mock the thingz",
+                  "completed": true
+                },
+                {
+                  "id": 3,
+                  "name": "code the thingz",
+                  "completed": false
+                }
+              ]
+            }
+          },
+          "500": {
+            "$ref": "../common/shared.yaml#/responses/500"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "todoId": {
+      "name": "todoId",
+      "in": "path",
+      "required": true,
+      "type": "string"
+    }
+  },
+  "responses": {
+    "420": {
+      "description": "Stay calm and carry on. Should render the user model",
+      "schema": {
+        "$ref": "./models/user.json"
+      }
+    }
+  },
+  "definitions": {
+    "embedded": {
+      "title": "Embedded Model",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "todo": {
+          "$ref": "./models/todo-full.json"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
While trying to merge https://github.com/stoplightio/platform-internal/pull/5377 which is a version bump of #16 e2e revealed a failing use-case.

`#/definitions/Error` got dereferenced

<img width="1494" alt="Screen Shot 2021-02-16 at 12 22 43" src="https://user-images.githubusercontent.com/1868852/108056569-b833da80-7051-11eb-9d30-2519f501621b.png">

and paths like `#/paths/~1todos/get/responses/500` were transformed into `#/responses/Shared_500` which seems ok, but `#responses/Shared_500` was never created so it points to a broken ref.

I've added a failing use-case in tests