### PR TITLE
fix: improve performance

### DIFF
--- a/lib/bundle/index.js
+++ b/lib/bundle/index.js
@@ -56,20 +56,33 @@ function crawl (parent, key, path, pathFromRoot, indirections, inventory, $refs,
       // which later determines which keys get dereferenced and which ones get remapped
       let keys = Object.keys(obj)
         .sort((a, b) => {
-          let aDefinitionsIndex = `${pathFromRoot}/${a}`.lastIndexOf(options.bundle.defaultRoot);
-          let bDefinitionsIndex = `${pathFromRoot}/${b}`.lastIndexOf(options.bundle.defaultRoot);
-          // Most people will expect references to be bundled into the the defaultRoot property,
-          // so we always crawl that property first, if it exists.
 
-          if (aDefinitionsIndex !== bDefinitionsIndex) {
-            // Give higher priority to the $ref that's closer to the "definitions" property
-            return bDefinitionsIndex - aDefinitionsIndex;
+
+          // performance optimization: indexOf is ~12 times faster than lastIndexOf as of now, LIO becomes a bottleneck in larger schemas
+          const aContainsDefinitions = `${pathFromRoot}/${a}`.indexOf(options.bundle.defaultRoot) !== -1;
+          const bContainsDefinitions = `${pathFromRoot}/${b}`.indexOf(options.bundle.defaultRoot) !== -1;
+
+          if (aContainsDefinitions && !bContainsDefinitions) {
+            return -1;
           }
-          else {
-            // Otherwise, crawl the keys based on their length.
-            // This produces the shortest possible bundled references
-            return a.length - b.length;
+          if (!aContainsDefinitions && bContainsDefinitions) {
+            return 1;
           }
+          if (aContainsDefinitions && bContainsDefinitions) {
+            let aDefinitionsIndex = `${pathFromRoot}/${a}`.lastIndexOf(options.bundle.defaultRoot);
+            let bDefinitionsIndex = `${pathFromRoot}/${b}`.lastIndexOf(options.bundle.defaultRoot);
+            // Most people will expect references to be bundled into the the defaultRoot property,
+            // so we always crawl that property first, if it exists.
+
+            if (aDefinitionsIndex !== bDefinitionsIndex) {
+              // Give higher priority to the $ref that's closer to the "definitions" property
+              return bDefinitionsIndex - aDefinitionsIndex;
+            }
+          }
+
+          // All else being equal, crawl the keys based on their length.
+          // This produces the shortest possible bundled references
+          return a.length - b.length;
         });
 
       // eslint-disable-next-line no-shadow
@@ -128,7 +141,7 @@ function inventory$Ref ($refParent, $refKey, path, pathFromRoot, indirections, i
     return;
   }
 
-  let depth = Pointer.parse(pathFromRoot).length;
+  let depth = Pointer.parseLength(pathFromRoot);
   let file = url.stripHash(pointer.path);
   let hash = url.getHash(pointer.path);
   let external = file !== $refs._root$Ref.path;
@@ -239,17 +252,22 @@ function remap (schema, inventory, $refs, options, customRoots) {
     else {
       // Determine how far each $ref is from the "definitions" property.
       // Most people will expect references to be bundled into the the "definitions" property if possible.
-      let aDefinitionsIndex = a.pathFromRoot.lastIndexOf(options.bundle.defaultRoot);
-      let bDefinitionsIndex = b.pathFromRoot.lastIndexOf(options.bundle.defaultRoot);
 
-      if (aDefinitionsIndex !== bDefinitionsIndex) {
-        // Give higher priority to the $ref that's closer to the "definitions" property
-        return bDefinitionsIndex - aDefinitionsIndex;
+      // performance optimization: indexOf is ~12 times faster than lastIndexOf as of now, LIO becomes a bottleneck in larger schemas
+      const aContainsDefinitions = a.pathFromRoot.indexOf(options.bundle.defaultRoot) !== -1;
+      const bContainsDefinitions = b.pathFromRoot.indexOf(options.bundle.defaultRoot) !== -1;
+      if (aContainsDefinitions || bContainsDefinitions) {
+
+        let aDefinitionsIndex = a.pathFromRoot.lastIndexOf(options.bundle.defaultRoot);
+        let bDefinitionsIndex = b.pathFromRoot.lastIndexOf(options.bundle.defaultRoot);
+
+        if (aDefinitionsIndex !== bDefinitionsIndex) {
+          // Give higher priority to the $ref that's closer to the "definitions" property
+          return bDefinitionsIndex - aDefinitionsIndex;
+        }
       }
-      else {
-        // All else is equal, so use the shorter path, which will produce the shortest possible reference
-        return a.pathFromRoot.length - b.pathFromRoot.length;
-      }
+      // All else is equal, so use the shorter path, which will produce the shortest possible reference
+      return a.pathFromRoot.length - b.pathFromRoot.length;
     }
   });
 

--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -189,6 +189,25 @@ Pointer.parse = function (path, originalPath) {
   return pointer.slice(1);
 };
 
+
+/**
+ * Like `Pointer.parse` but only returns the length of the pointer.
+ * Same as `Pointer.parse(path).length` but faster.
+ * @param path
+ * @returns {number}
+ */
+Pointer.parseLength = function (path) {
+  // Get the JSON pointer from the path's hash
+  let pointer = url.getHash(path).substr(1);
+
+  // If there's no pointer, then there are no tokens
+  if (!pointer) {
+    return 0;
+  }
+
+  return (pointer.match(/\//g) || []).length;
+};
+
 /**
  * Creates a JSON pointer path, by joining one or more tokens to a base path.
  *


### PR DESCRIPTION
Performance improvements.

See stoplightio/elements#1064 for details.

1. `lastIndexOf` is surprisingly much slower than `indexOf`, like we're talking 35x slower. https://www.measurethat.net/Benchmarks/Show/3384/0/index-vs-lastindexof#latest_results_block This created a performance bottleneck when parsing large documents, with hundereds of refs. A more invasive but even better solution would be to just skip the document entirely if it's already bundled. 
2. $ref parsing is called many times and url encoding/decoding is slow. (For the stripe example I measured ~1s for that single function). When we only need the length, no need to parse the whole thing.

