### PR TITLE
improve MissingPointerError message

### DIFF
--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -97,7 +97,7 @@ Pointer.prototype.resolve = function (obj, options, pathFromRoot) {
     let token = tokens[i];
     if (this.value[token] === undefined || this.value[token] === null) {
       this.value = null;
-      throw new MissingPointerError(token, this.originalPath);
+      throw new MissingPointerError(this.path, pathFromRoot, token, this.originalPath);
     }
     else {
       this.value = this.value[token];

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -2,7 +2,7 @@
 
 const { Ono } = require("@jsdevtools/ono");
 
-const { stripHash, toFileSystemPath } = require("./url");
+const { getHash, stripHash, toFileSystemPath } = require("./url");
 
 const JSONParserError = exports.JSONParserError = class JSONParserError extends Error {
   constructor (message, source) {
@@ -93,8 +93,8 @@ const UnmatchedResolverError = exports.UnmatchedResolverError = class UnmatchedR
 setErrorName(UnmatchedResolverError);
 
 const MissingPointerError = exports.MissingPointerError = class MissingPointerError extends JSONParserError {
-  constructor (token, path) {
-    super(`Token "${token}" does not exist.`, stripHash(path));
+  constructor (unresolvableRefValue, pathToUnresolvableRef, unresolvableTokenInRef, path) {
+    super(`at "${getHash(pathToUnresolvableRef)}", token "${unresolvableTokenInRef}" in "${getHash(unresolvableRefValue)}" does not exist`, stripHash(path));
 
     this.code = "EMISSINGPOINTER";
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stoplight/json-schema-ref-parser",
-  "version": "9.2.2",
+  "version": "9.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stoplight/json-schema-ref-parser",
-      "version": "9.2.2",
+      "version": "9.2.4",
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",

--- a/test/specs/missing-pointers/missing-pointers.spec.js
+++ b/test/specs/missing-pointers/missing-pointers.spec.js
@@ -16,7 +16,7 @@ describe("Schema with missing pointers", () => {
     }
     catch (err) {
       expect(err).to.be.an.instanceOf(MissingPointerError);
-      expect(err.message).to.contain("Token \"baz\" does not exist.");
+      expect(err.message).to.equal('at "#/foo", token "baz" in "#/baz" does not exist');
     }
   });
 
@@ -31,12 +31,13 @@ describe("Schema with missing pointers", () => {
       expect(err.files).to.equal(parser);
       expect(err.files.$refs._root$Ref.value).to.deep.equal({ foo: null });
       expect(err.message).to.have.string("1 error occurred while reading '");
+      console.log(err.errors[0].source);
+
       expect(err.errors).to.containSubset([
         {
           name: MissingPointerError.name,
-          message: "Token \"baz\" does not exist.",
+          message: 'at "#/foo", token "baz" in "#/baz" does not exist',
           path: ["foo"],
-          source: message => message.endsWith("/test/") || message.startsWith("http://localhost"),
         }
       ]);
     }

--- a/test/specs/refs.spec.js
+++ b/test/specs/refs.spec.js
@@ -216,7 +216,7 @@ describe("$Refs object", () => {
       }
       catch (err) {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal('Token "" does not exist.');
+        expect(err.message).to.equal('at "#", token "" in "#/" does not exist');
       }
     });
 
@@ -254,7 +254,7 @@ describe("$Refs object", () => {
       }
       catch (err) {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal('Token "foo" does not exist.');
+        expect(err.message).to.equal('at "#", token "foo" in "#/foo/bar" does not exist');
       }
     });
   });


### PR DESCRIPTION
## Motivation and Context

Based on Prism user feedback in https://github.com/stoplightio/prism/issues/2195, improve the `MissingPointerError` message to make it easier for an end user to understand exactly how `$ref` resolution failed.

## Description

Rather than the error message

```
    Token "definitions" does not exist.
```

instead provide the message

```
    at "#/components/examples/AppUserSchemaResponse/value/properties/profile/allOf/0", token "definitions" in "#/definitions/base" does not exist
```

## How Has This Been Tested?
I tested this change locally via unit tests, and in conjunction with Stoplight Prism.  Existing unit tests already provided coverage, but assertions/expectations had to be adjusted.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
