### PR TITLE
fix: recursively resolve and dereference extended refs

### DIFF
--- a/lib/bundle/index.js
+++ b/lib/bundle/index.js
@@ -78,14 +78,7 @@ function crawl (parent, key, path, pathFromRoot, indirections, inventory, $refs,
       for (let key of keys) {
         let keyPath = Pointer.join(path, key);
         let keyPathFromRoot = Pointer.join(pathFromRoot, key);
-        let value = obj[key];
-
-        if ($Ref.isAllowed$Ref(value)) {
-          inventory$Ref(obj, key, path, keyPathFromRoot, indirections, inventory, $refs, options, customRoots);
-        }
-        else {
-          crawl(obj, key, keyPath, keyPathFromRoot, indirections, inventory, $refs, options, customRoots);
-        }
+        crawl(obj, key, keyPath, keyPathFromRoot, indirections, inventory, $refs, options, customRoots);
       }
     }
   }

--- a/lib/resolve-external.js
+++ b/lib/resolve-external.js
@@ -58,18 +58,10 @@ function crawl (obj, path, $refs, options) {
     if ($Ref.isExternal$Ref(obj)) {
       promises.push(resolve$Ref(obj, path, $refs, options));
     }
-    else {
-      for (let key of Object.keys(obj)) {
-        let keyPath = Pointer.join(path, key);
-        let value = obj[key];
-
-        if ($Ref.isExternal$Ref(value)) {
-          promises.push(resolve$Ref(value, keyPath, $refs, options));
-        }
-        else {
-          promises = promises.concat(crawl(value, keyPath, $refs, options));
-        }
-      }
+    for (let key of Object.keys(obj)) {
+      let keyPath = Pointer.join(path, key);
+      let value = obj[key];
+      promises = promises.concat(crawl(value, keyPath, $refs, options));
     }
   }
 

--- a/test/specs/nested-extended/dereferenced.js
+++ b/test/specs/nested-extended/dereferenced.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+  const: "root",
+  objectchild: {
+    const: "object-child",
+  },
+  arraychild: [
+    {
+      const: "array-child",
+    },
+  ],
+};

--- a/test/specs/nested-extended/dereferenced.js
+++ b/test/specs/nested-extended/dereferenced.js
@@ -10,4 +10,7 @@ module.exports = {
       const: "array-child",
     },
   ],
+  local: {
+    const: "local",
+  }
 };

--- a/test/specs/nested-extended/nested-extended.spec.js
+++ b/test/specs/nested-extended/nested-extended.spec.js
@@ -39,4 +39,13 @@ describe("Schema with a $ref nested inside an extended $ref", () => {
     expect(schema).to.equal(parser.schema);
     expect(schema).to.deep.equal(dereferencedSchema);
   });
+
+  it("should bundle successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.bundle(
+      path.rel("specs/nested-extended/nested-extended.yaml")
+    );
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(dereferencedSchema);
+  });
 });

--- a/test/specs/nested-extended/nested-extended.spec.js
+++ b/test/specs/nested-extended/nested-extended.spec.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const chai = require("chai");
+const chaiSubset = require("chai-subset");
+chai.use(chaiSubset);
+const { expect } = chai;
+const $RefParser = require("../../../lib");
+const helper = require("../../utils/helper");
+const path = require("../../utils/path");
+const parsedSchema = require("./parsed");
+const dereferencedSchema = require("./dereferenced");
+
+describe("Schema with a $ref nested inside an extended $ref", () => {
+  it("should parse successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.parse(
+      path.rel("specs/nested-extended/nested-extended.yaml")
+    );
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(parsedSchema.schema);
+    expect(parser.$refs.paths()).to.deep.equal([
+      path.abs("specs/nested-extended/nested-extended.yaml"),
+    ]);
+  });
+
+  it("should resolve successfully", helper.testResolve(
+    path.rel("specs/nested-extended/nested-extended.yaml"),
+    path.abs("specs/nested-extended/nested-extended.yaml"), parsedSchema.schema,
+    path.abs("specs/nested-extended/referenced-root.yaml"), parsedSchema.root,
+    path.abs("specs/nested-extended/referenced-object-child.yaml"), parsedSchema.objectchild,
+    path.abs("specs/nested-extended/referenced-array-child.yaml"), parsedSchema.arraychild
+  ));
+
+  it("should dereference successfully", async () => {
+    let parser = new $RefParser();
+    const schema = await parser.dereference(
+      path.rel("specs/nested-extended/nested-extended.yaml")
+    );
+    expect(schema).to.equal(parser.schema);
+    expect(schema).to.deep.equal(dereferencedSchema);
+  });
+});

--- a/test/specs/nested-extended/nested-extended.yaml
+++ b/test/specs/nested-extended/nested-extended.yaml
@@ -1,0 +1,5 @@
+$ref: "referenced-root.yaml"
+objectchild:
+  $ref: "referenced-object-child.yaml"
+arraychild:
+  - $ref: "referenced-array-child.yaml"

--- a/test/specs/nested-extended/nested-extended.yaml
+++ b/test/specs/nested-extended/nested-extended.yaml
@@ -3,3 +3,8 @@ objectchild:
   $ref: "referenced-object-child.yaml"
 arraychild:
   - $ref: "referenced-array-child.yaml"
+local:
+  $ref: "#/$defs/local"
+$defs:
+  local:
+    const: "local"

--- a/test/specs/nested-extended/parsed.js
+++ b/test/specs/nested-extended/parsed.js
@@ -11,6 +11,14 @@ module.exports = {
         $ref: "referenced-array-child.yaml",
       },
     ],
+    local: {
+      $ref: "#/$defs/local",
+    },
+    $defs: {
+      local: {
+        const: "local",
+      },
+    },
   },
 
   root: {

--- a/test/specs/nested-extended/parsed.js
+++ b/test/specs/nested-extended/parsed.js
@@ -1,0 +1,27 @@
+"use strict";
+
+module.exports = {
+  schema: {
+    $ref: "referenced-root.yaml",
+    objectchild: {
+      $ref: "referenced-object-child.yaml",
+    },
+    arraychild: [
+      {
+        $ref: "referenced-array-child.yaml",
+      },
+    ],
+  },
+
+  root: {
+    const: "root",
+  },
+
+  objectchild: {
+    const: "object-child",
+  },
+
+  arraychild: {
+    const: "array-child",
+  },
+};

--- a/test/specs/nested-extended/referenced-array-child.yaml
+++ b/test/specs/nested-extended/referenced-array-child.yaml
@@ -1,0 +1,1 @@
+const: "array-child"

--- a/test/specs/nested-extended/referenced-object-child.yaml
+++ b/test/specs/nested-extended/referenced-object-child.yaml
@@ -1,0 +1,1 @@
+const: "object-child"

--- a/test/specs/nested-extended/referenced-root.yaml
+++ b/test/specs/nested-extended/referenced-root.yaml
@@ -1,0 +1,1 @@
+const: "root"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
(tests don't pass, not ready to merge, see description)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves https://github.com/stoplightio/json-schema-ref-parser/issues/44

This is blocking my usage of this library, and I don't have any other workaround besides writing my own custom resolving or dereferencing.

## Description
<!-- Describe your technical changes in detail. -->
- When crawling over the schema to resolve or bundle its refs, remove an `else` so that the crawl recurses into the children of an object even if it has a $ref.
- New unit tests.

Unfortunately there's also a bug in dereferencing, and I've tried to fix it, but the dereferencing recursion is more complicated and I wasn't able to figure it out on my own. This would need attention from a maintainer to fix it.

Specifically the new test fails with
<details>
<summary>
MissingPointerError: at "#/local", token "$defs" in "#/$defs/local" does not exist
</summary>

```
  1) Schema with a $ref nested inside an extended $ref
       should dereference successfully:
     MissingPointerError: at "#/local", token "$defs" in "#/$defs/local" does not exist
      at Pointer.resolve (lib/pointer.js:100:13)
      at $Ref.resolve (lib/ref.js:126:28)
      at $Refs._resolve (lib/refs.js:165:15)
      at dereference$Ref (lib/dereference.js:115:23)
      at crawl (lib/dereference.js:62:26)
      at dereference$Ref (lib/dereference.js:157:24)
      at crawl (lib/dereference.js:49:22)
      at dereference (lib/dereference.js:21:22)
      at $RefParser.dereference (lib/index.js:270:5)
      at async Context.<anonymous> (test/specs/nested-extended/nested-extended.spec.js:36:20)
```

</details>

And in `lib/dereference.js:dereference$Ref` the path is wrong. The log statement  (currently commented out) incorrectly says
```
Dereferencing $ref pointer "#/$defs/local" at /Users/srose/git/json-schema-ref-parser/test/specs/nested-extended/referenced-root.yaml#/local`
```
(note that `referenced-root.yaml#/local` doesn't exist)

If you remove the top level `$ref: "referenced-root.yaml"` from `test/specs/nested-extended/nested-extended.yaml` (so it's not an extended ref anymore), that same log says (correctly)
```
Dereferencing $ref pointer "#/$defs/local" at /Users/srose/git/json-schema-ref-parser/test/specs/nested-extended/nested-extended.yaml#/local
```

I tried to fix this, but I didn't understand enough about how paths are made and what they mean. Someone who's more familiar with the code would need to fix `dereference.js` so that the new test passes.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
- New unit tests for parsing and resolving extended refs.
- New unit test for dereferencing, that doesn't pass and I can't fix on my own.
- New unit test for bundling, which also fails, and I don't know if it's because of the dereferencing issue or because I misunderstood how bundling is supposed to work.
- Other unit tests (mostly) pass locally. (I'm pretty sure it's just flaky CI tests that fail.)
- I've tried to run on my own project, to check that it works in a real-world use case, but got stuck on the dereferencing issue, so can't confirm this yet.


## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This is a behavior change, so could potentially be considered breaking, but I think it still falls under "bug fix".

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
